### PR TITLE
Honor explicit pairwise transforms in relationship analysis (Vibe Kanban)

### DIFF
--- a/src/fred_query/services/relationship_service.py
+++ b/src/fred_query/services/relationship_service.py
@@ -8,6 +8,7 @@ from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
 from fred_query.services.fred_client import FREDClient
 from fred_query.services.transform_service import TransformService
+from fred_query.schemas.intent import TransformType
 
 
 class RelationshipAnalysisService:
@@ -133,15 +134,35 @@ class RelationshipAnalysisService:
 
         start_date = intent.start_date or self._default_start_date()
         end_date = intent.end_date
+        effective_transform = (
+            TransformType.LEVEL if intent.transform == TransformType.NORMALIZED_INDEX else intent.transform
+        )
+        transform_window, transform_warnings = self.transform_service.resolve_transform_window(
+            transform=effective_transform,
+            frequency=metadata_items[0].frequency,
+            requested_window=intent.transform_window,
+        )
+        warmup_periods = self.transform_service.transform_warmup_periods(
+            transform=effective_transform,
+            periods_per_year=periods_per_year,
+            window=transform_window,
+        )
+        fetch_start_date = self.transform_service.subtract_periods(
+            start_date,
+            periods=warmup_periods,
+            frequency=frequency_code,
+        )
         raw_observations: list[list] = []
         transformed_observations: list[list] = []
         bases: list[str] = []
         analysis_units: list[str] = []
+        warnings = list(transform_warnings)
+        applied_transform_window: int | None = None
 
         for metadata in metadata_items:
             observations = self.fred_client.get_series_observations(
                 metadata.series_id,
-                start_date=start_date,
+                start_date=fetch_start_date,
                 end_date=end_date,
                 frequency=frequency_code,
                 aggregation_method="avg",
@@ -149,21 +170,49 @@ class RelationshipAnalysisService:
             if not observations:
                 raise ValueError(f"No observations returned for {metadata.series_id}.")
 
-            transformed, basis, units = self.transform_service.build_relationship_basis(
+            visible_observations = self.transform_service.filter_observations_by_date(
                 observations,
-                title=metadata.title,
-                units=metadata.units,
-                periods_per_year=periods_per_year,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            if not visible_observations:
+                raise ValueError(f"No observations returned for {metadata.series_id} in the requested display window.")
+
+            basis_source_observations = observations if warmup_periods > 0 else visible_observations
+            transformed, basis, units, applied_window, basis_warnings = (
+                self.transform_service.build_relationship_basis(
+                    basis_source_observations,
+                    title=metadata.title,
+                    units=metadata.units,
+                    frequency=metadata.frequency,
+                    periods_per_year=periods_per_year,
+                    transform=intent.transform,
+                    normalization=intent.normalization,
+                    requested_window=transform_window,
+                )
             )
             if not transformed:
                 raise ValueError(
                     f"I could not derive a stable comparison basis for {metadata.series_id} over the requested date range."
                 )
 
-            raw_observations.append(observations)
+            transformed = self.transform_service.filter_observations_by_date(
+                transformed,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            if not transformed:
+                raise ValueError(
+                    f"I could not derive {basis.lower()} for {metadata.series_id} over the requested display window."
+                )
+
+            raw_observations.append(visible_observations)
             transformed_observations.append(transformed)
             bases.append(basis)
             analysis_units.append(units)
+            if applied_window is not None:
+                applied_transform_window = applied_window
+            warnings.extend(basis_warnings)
 
         aligned_first, aligned_second = self.transform_service.align_on_dates(
             transformed_observations[0],
@@ -184,7 +233,6 @@ class RelationshipAnalysisService:
 
         chart_series = [aligned_first, aligned_second]
         chart_units = analysis_units[0]
-        warnings: list[str] = []
         basis_summary = (
             bases[0]
             if bases[0] == bases[1]
@@ -235,6 +283,19 @@ class RelationshipAnalysisService:
                 description="Number of aligned observations used in the same-period relationship estimate.",
             ),
         ]
+        if applied_transform_window is not None and effective_transform in (
+            TransformType.ROLLING_AVERAGE,
+            TransformType.ROLLING_STDDEV,
+            TransformType.ROLLING_VOLATILITY,
+        ):
+            derived_metrics.append(
+                DerivedMetric(
+                    name="applied_transform_window",
+                    value=applied_transform_window,
+                    unit="observations",
+                    description="Rolling window length used for the pairwise analysis basis.",
+                )
+            )
 
         if same_period_correlation is not None:
             derived_metrics.append(

--- a/src/fred_query/services/transform_service.py
+++ b/src/fred_query/services/transform_service.py
@@ -378,21 +378,47 @@ class TransformService:
         *,
         title: str,
         units: str,
+        frequency: str | None,
         periods_per_year: int,
-    ) -> tuple[list[ObservationPoint], str, str]:
+        transform: TransformType = TransformType.LEVEL,
+        normalization: bool = False,
+        requested_window: int | None = None,
+    ) -> tuple[list[ObservationPoint], str, str, int | None, list[str]]:
+        effective_transform = TransformType.LEVEL if transform == TransformType.NORMALIZED_INDEX else transform
+        normalize_chart = normalization or transform == TransformType.NORMALIZED_INDEX
+
+        if effective_transform != TransformType.LEVEL:
+            transform_result = self.apply_single_series_transform(
+                observations,
+                transform=effective_transform,
+                units=units,
+                frequency=frequency,
+                window=requested_window,
+            )
+            return (
+                transform_result.observations or [],
+                transform_result.basis or effective_transform.value.replace("_", " "),
+                transform_result.units,
+                transform_result.applied_window,
+                list(transform_result.warnings),
+            )
+
+        if normalize_chart:
+            return self.normalize_to_index(observations), "Normalized index", "Index (Base = 100)", None, []
+
         if self.should_use_level_relationship(title, units):
-            return observations, "Reported level", units
+            return observations, "Reported level", units, None, []
 
         if periods_per_year > 1:
             year_over_year = self.calculate_pct_change(observations, periods=periods_per_year)
             if len(year_over_year) >= max(8, periods_per_year):
-                return year_over_year, "Year-over-year percent change", "Percent"
+                return year_over_year, "Year-over-year percent change", "Percent", None, []
 
         period_change = self.calculate_pct_change(observations, periods=1)
         if period_change:
-            return period_change, "Period-over-period percent change", "Percent"
+            return period_change, "Period-over-period percent change", "Percent", None, []
 
-        return observations, "Reported level", units
+        return observations, "Reported level", units, None, []
 
     @staticmethod
     def align_on_dates(

--- a/tests/test_relationship_service.py
+++ b/tests/test_relationship_service.py
@@ -4,7 +4,7 @@ from datetime import date
 import unittest
 
 from fred_query.schemas.analysis import ObservationPoint
-from fred_query.schemas.intent import ComparisonMode, QueryIntent, TaskType
+from fred_query.schemas.intent import ComparisonMode, QueryIntent, TaskType, TransformType
 from fred_query.schemas.resolved_series import SeriesMetadata, SeriesSearchMatch
 from fred_query.services.relationship_service import RelationshipAnalysisService
 
@@ -104,6 +104,45 @@ class RelationshipAnalysisServiceTest(unittest.TestCase):
         self.assertIn("association estimate", response.answer_text.lower())
         self.assertIn("DCOILBRENTEU", response.answer_text)
         self.assertEqual(client.requests[0], ("DCOILBRENTEU", "m", "avg"))
+
+    def test_analyze_honors_explicit_transform_for_pairwise_requests(self) -> None:
+        client = _FakeFREDClient()
+        service = RelationshipAnalysisService(client)
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            indicators=["brent crude oil prices", "inflation"],
+            search_texts=["brent crude oil price", "inflation united states"],
+            start_date=date(2020, 1, 1),
+            transform=TransformType.YEAR_OVER_YEAR_PERCENT_CHANGE,
+        )
+
+        response = service.analyze(intent)
+
+        self.assertEqual(response.analysis.series_results[0].analysis_basis, "Year-over-year percent change")
+        self.assertEqual(response.analysis.series_results[0].analysis_units, "Percent")
+        self.assertEqual(response.analysis.series_results[1].analysis_basis, "Year-over-year percent change")
+        self.assertEqual(response.analysis.derived_metrics[0].value, "Year-over-year percent change")
+
+    def test_analyze_honors_normalization_for_pairwise_requests(self) -> None:
+        client = _FakeFREDClient()
+        service = RelationshipAnalysisService(client)
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            indicators=["brent crude oil prices", "inflation"],
+            search_texts=["brent crude oil price", "inflation united states"],
+            start_date=date(2020, 1, 1),
+            transform=TransformType.NORMALIZED_INDEX,
+            normalization=True,
+        )
+
+        response = service.analyze(intent)
+
+        self.assertEqual(response.analysis.series_results[0].analysis_basis, "Normalized index")
+        self.assertEqual(response.analysis.series_results[0].analysis_units, "Index (Base = 100)")
+        self.assertEqual(response.analysis.series_results[0].transformed_observations[0].value, 100.0)
+        self.assertEqual(response.analysis.derived_metrics[0].value, "Normalized index")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update pairwise relationship analysis to honor explicit `intent.transform` and `intent.normalization` instead of always falling back to the heuristic relationship basis
- route pairwise execution through the transform service so explicit YoY, normalized index, and rolling transforms use the same deterministic transform logic as single-series analysis
- add regression coverage for explicit year-over-year and normalized pairwise requests

## Why
The task context for this branch is a follow-up intent bug: `natural_language_query_service.py` preserved transform changes correctly, but `relationship_service.py` ignored them during execution. That meant pairwise follow-ups could report the requested transform in intent state while still analyzing and labeling the series as `Reported level`, which broke the user-visible result and made the transform controls unreliable.

## Implementation Details
- `relationship_service.py` now derives an effective pairwise transform from the request intent, resolves any rolling window, and fetches warmup history when the requested transform needs prior observations.
- pairwise execution now filters raw observations to the requested display window while still using extended fetch windows when required for YoY and rolling calculations.
- `transform_service.py` now allows the relationship-basis builder to accept explicit transform, normalization, frequency, and requested window inputs, returning transform warnings and any applied rolling window along with the transformed series.
- normalization is anchored to the visible request window when no warmup is needed, so normalized pairwise charts start at the expected base value instead of pre-range history.
- the relationship analysis output now carries forward transform warnings and records `applied_transform_window` when rolling transforms are used.
- tests were added to verify that pairwise relationship analysis produces `Year-over-year percent change` and `Normalized index` bases when those transforms are explicitly requested.

This PR was written using [Vibe Kanban](https://vibekanban.com)