### PR TITLE
Align latest cross-section rankings by shared snapshot date (Vibe Kanban)

### DIFF
--- a/src/fred_query/services/cross_section_service.py
+++ b/src/fred_query/services/cross_section_service.py
@@ -52,6 +52,10 @@ class CrossSectionService:
             return "Latest available observation"
         return f"Latest observation on or before {observation_date.isoformat()}"
 
+    @staticmethod
+    def _aligned_snapshot_basis(observation_date: date) -> str:
+        return f"Latest cross-section aligned on or before {observation_date.isoformat()}"
+
     def _resolve_single_series(self, intent: QueryIntent, indicator_text: str) -> ResolvedSeries:
         if intent.series_id:
             metadata = self.fred_client.get_series_metadata(intent.series_id)
@@ -172,6 +176,29 @@ class CrossSectionService:
             raise ValueError(f"No observations returned for {series.series_id} at {date_text}.")
         return observations[0]
 
+    def _resolve_snapshot_date(
+        self,
+        resolved_series: list[ResolvedSeries],
+        *,
+        observation_date: date | None,
+        frequency: str | None,
+    ) -> tuple[date | None, str]:
+        if observation_date is not None or len(resolved_series) <= 1:
+            return observation_date, self._snapshot_basis(observation_date)
+
+        latest_points: list[ObservationPoint] = []
+        for resolved in resolved_series:
+            latest_points.append(
+                self._fetch_snapshot_point(
+                    resolved,
+                    observation_date=None,
+                    frequency=frequency,
+                )
+            )
+
+        aligned_date = min(point.date for point in latest_points)
+        return aligned_date, self._aligned_snapshot_basis(aligned_date)
+
     @staticmethod
     def _sort_results(
         series_results: list[SeriesAnalysis],
@@ -202,13 +229,18 @@ class CrossSectionService:
         response_intent.cross_section_scope = scope
 
         indicator_text = self._indicator_text(response_intent)
-        observation_date = response_intent.observation_date or response_intent.end_date
-        response_intent.observation_date = observation_date
+        requested_observation_date = response_intent.observation_date or response_intent.end_date
 
         resolved_series = self._resolve_series(response_intent, scope, indicator_text)
         if scope == CrossSectionScope.SINGLE_SERIES and resolved_series:
             response_intent.series_id = resolved_series[0].series_id
             response_intent.search_text = response_intent.search_text or indicator_text
+        observation_date, snapshot_basis = self._resolve_snapshot_date(
+            resolved_series,
+            observation_date=requested_observation_date,
+            frequency=response_intent.frequency,
+        )
+        response_intent.observation_date = observation_date
         series_results: list[SeriesAnalysis] = []
         warnings: list[str] = []
 
@@ -250,7 +282,6 @@ class CrossSectionService:
 
         response_intent.rank_limit = display_limit if len(displayed_results) != len(ranked_results) else response_intent.rank_limit
         leader = ranked_results[0]
-        snapshot_basis = self._snapshot_basis(observation_date)
         rank_label = "highest" if response_intent.sort_descending else "lowest"
 
         derived_metrics = [

--- a/tests/test_cross_section_service.py
+++ b/tests/test_cross_section_service.py
@@ -16,6 +16,7 @@ class CrossSectionServiceTest(unittest.TestCase):
     def _build_state_ranking_client(
         self,
         state_values: dict[str, tuple[str, float]] | None = None,
+        observation_payloads_by_series: dict[str, list[dict[str, str]]] | None = None,
     ) -> tuple[FREDClient, list[dict[str, str]]]:
         requests: list[dict[str, str]] = []
         state_values = state_values or {
@@ -38,7 +39,14 @@ class CrossSectionServiceTest(unittest.TestCase):
                     }
                 ]
             }
-            observation_payloads[series_id] = {"observations": [{"date": "2024-01-01", "value": str(value)}]}
+            observations = (
+                observation_payloads_by_series.get(series_id)
+                if observation_payloads_by_series is not None
+                else None
+            )
+            observation_payloads[series_id] = {
+                "observations": observations or [{"date": "2024-01-01", "value": str(value)}]
+            }
 
         def handler(request: httpx.Request) -> httpx.Response:
             requests.append(dict(request.url.params))
@@ -47,7 +55,22 @@ class CrossSectionServiceTest(unittest.TestCase):
                 return httpx.Response(status_code=200, text=json.dumps(metadata_payloads[series_id]))
             if request.url.path.endswith("/series/observations"):
                 series_id = request.url.params["series_id"]
-                return httpx.Response(status_code=200, text=json.dumps(observation_payloads[series_id]))
+                observations = observation_payloads[series_id]["observations"]
+                observation_end = request.url.params.get("observation_end")
+                if observation_end:
+                    observations = [
+                        item for item in observations if item["date"] <= observation_end
+                    ]
+                sort_order = request.url.params.get("sort_order")
+                observations = sorted(
+                    observations,
+                    key=lambda item: item["date"],
+                    reverse=sort_order == "desc",
+                )
+                limit = request.url.params.get("limit")
+                if limit:
+                    observations = observations[: int(limit)]
+                return httpx.Response(status_code=200, text=json.dumps({"observations": observations}))
             return httpx.Response(status_code=404, json={"error_message": "not found"})
 
         transport = httpx.MockTransport(handler)
@@ -122,7 +145,7 @@ class CrossSectionServiceTest(unittest.TestCase):
         self.assertEqual(response.chart.series[0].y, [6.5, 5.0])
         self.assertIn("Nevada ranks highest", response.answer_text)
         observation_requests = [item for item in requests if item.get("series_id") in {"CAUR", "TXUR", "NVUR"} and item.get("sort_order") == "desc"]
-        self.assertEqual(len(observation_requests), 3)
+        self.assertEqual(len(observation_requests), 6)
         self.assertTrue(all(item.get("limit") == "1" for item in observation_requests))
         self.assertEqual(response.chart.to_plotly_dict()["data"][0]["type"], "bar")
 
@@ -186,6 +209,47 @@ class CrossSectionServiceTest(unittest.TestCase):
         self.assertEqual(response.chart.series[0].y, [300.54])
         self.assertEqual(response.analysis.series_results[0].latest_observation_date, date(2023, 1, 1))
         self.assertIn("2023-01-01", response.answer_text)
+
+    def test_latest_cross_section_aligns_to_shared_snapshot_date(self) -> None:
+        observation_payloads = {
+            "CAUR": [
+                {"date": "2024-01-01", "value": "4.0"},
+                {"date": "2023-01-01", "value": "5.0"},
+            ],
+            "TXUR": [
+                {"date": "2023-01-01", "value": "4.5"},
+            ],
+        }
+        client, _ = self._build_state_ranking_client(
+            state_values={"CA": ("California", 4.0), "TX": ("Texas", 4.5)},
+            observation_payloads_by_series=observation_payloads,
+        )
+        service = CrossSectionService(client)
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            indicators=["unemployment rate"],
+            search_text="unemployment rate",
+            comparison_mode=ComparisonMode.CROSS_SECTION,
+            cross_section_scope=CrossSectionScope.STATES,
+        )
+
+        with patch.dict(
+            "fred_query.services.cross_section_service.STATE_CODE_TO_NAME",
+            {"CA": "California", "TX": "Texas"},
+            clear=True,
+        ):
+            response = service.analyze(intent)
+
+        self.assertEqual(response.intent.observation_date, date(2023, 1, 1))
+        self.assertEqual(
+            [result.series.geography for result in response.analysis.series_results],
+            ["California", "Texas"],
+        )
+        self.assertEqual(
+            [result.latest_observation_date for result in response.analysis.series_results],
+            [date(2023, 1, 1), date(2023, 1, 1)],
+        )
+        self.assertIn("Latest cross-section aligned on or before 2023-01-01", response.answer_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- align implicit latest cross-section rankings to a shared snapshot date instead of comparing each series on its own most recent observation
- update the snapshot wording so answers and chart subtitles describe the aligned cutoff date explicitly
- add regression coverage for the stale-2023-vs-2024 ranking case and improve the test FRED mock so it respects `observation_end`, `sort_order`, and `limit`

## Why
The existing cross-section flow fetched each series' own latest point and ranked those values together. That could produce misleading latest rankings where an older observation out-ranked a newer one while the answer still claimed the result used the latest available observation. This change makes the ranking basis date-consistent across the compared series.

## Implementation Details
- `CrossSectionService` now resolves a shared snapshot date for multi-series implicit-latest cross sections by fetching each series' latest available point and taking the earliest of those dates as the common cutoff.
- After determining that cutoff, the service re-fetches each series on or before the shared date before sorting and building the response.
- The response intent now records the resolved aligned observation date, and the derived `snapshot_basis` text now distinguishes aligned implicit-latest snapshots from explicit date requests.
- The cross-section tests were expanded to cover the date-alignment regression and to make the mocked FRED observation endpoint behave more like the real API.

## Testing
- `python -m pytest tests\\test_cross_section_service.py`
- `python -m pytest tests\\test_follow_up_suggestions.py tests\\test_chart_service.py tests\\test_cli.py tests\\test_natural_language_query_service.py`

This PR was written using [Vibe Kanban](https://vibekanban.com)