### PR TITLE
Centralize series resolution and execution scaffolding

### DIFF
--- a/src/fred_query/services/cross_section_service.py
+++ b/src/fred_query/services/cross_section_service.py
@@ -53,39 +53,13 @@ class CrossSectionService:
         return f"Latest observation on or before {observation_date.isoformat()}"
 
     def _resolve_single_series(self, intent: QueryIntent, indicator_text: str) -> ResolvedSeries:
-        if intent.series_id:
-            metadata = self.fred_client.get_series_metadata(intent.series_id)
-            return ResolvedSeries(
-                series_id=metadata.series_id,
-                title=metadata.title,
-                geography=intent.geographies[0].name if intent.geographies else "Unspecified",
-                indicator=self._indicator_slug(indicator_text),
-                units=metadata.units,
-                frequency=metadata.frequency,
-                seasonal_adjustment=metadata.seasonal_adjustment,
-                score=1.0,
-                resolution_reason=f"Used explicit series ID {metadata.series_id}.",
-                source_url=metadata.source_url,
-            )
-
-        matches = self.fred_client.search_series(indicator_text, limit=5)
-        if not matches:
-            raise ValueError(f"No FRED series matched search text '{indicator_text}'.")
-
-        search_match = matches[0]
-        metadata = self.fred_client.get_series_metadata(search_match.series_id)
-        return ResolvedSeries(
-            series_id=metadata.series_id,
-            title=metadata.title,
+        resolved, _, _ = self.resolver_service.resolve_series(
+            explicit_series_id=intent.series_id,
+            search_text=indicator_text,
             geography=intent.geographies[0].name if intent.geographies else "Unspecified",
             indicator=self._indicator_slug(indicator_text),
-            units=metadata.units,
-            frequency=metadata.frequency,
-            seasonal_adjustment=metadata.seasonal_adjustment,
-            score=0.8,
-            resolution_reason=f"Resolved the query via FRED search. Top match was {metadata.series_id}.",
-            source_url=metadata.source_url,
         )
+        return resolved
 
     def _resolve_geography_series(self, intent: QueryIntent, indicator_text: str) -> list[ResolvedSeries]:
         resolved_series: list[ResolvedSeries] = []
@@ -112,29 +86,15 @@ class CrossSectionService:
             geography_search = " ".join(
                 part for part in [geography.name, intent.search_text or indicator_text] if part
             )
-            matches = self.fred_client.search_series(geography_search, limit=5)
-            if not matches:
-                raise ValueError(f"No FRED series matched search text '{geography_search}'.")
-
-            search_match = matches[0]
-            metadata = self.fred_client.get_series_metadata(search_match.series_id)
-            resolved_series.append(
-                ResolvedSeries(
-                    series_id=metadata.series_id,
-                    title=metadata.title,
-                    geography=geography.name,
-                    indicator=self._indicator_slug(indicator_text),
-                    units=metadata.units,
-                    frequency=metadata.frequency,
-                    seasonal_adjustment=metadata.seasonal_adjustment,
-                    score=0.8,
-                    resolution_reason=(
-                        f"Resolved {geography.name} via FRED search. Top match for '{geography_search}' "
-                        f"was {metadata.series_id}."
-                    ),
-                    source_url=metadata.source_url,
-                )
+            resolved, _, _ = self.resolver_service.resolve_series(
+                search_text=geography_search,
+                geography=geography.name,
+                indicator=self._indicator_slug(indicator_text),
+                search_resolution_reason=(
+                    "Resolved {geography} via FRED search. Top match for '{search_text}' was {series_id}."
+                ),
             )
+            resolved_series.append(resolved)
         return resolved_series
 
     def _resolve_series(self, intent: QueryIntent, scope: CrossSectionScope, indicator_text: str) -> list[ResolvedSeries]:
@@ -159,17 +119,18 @@ class CrossSectionService:
         frequency: str | None,
     ) -> ObservationPoint:
         aggregation_method = "avg" if frequency else None
-        observations = self.fred_client.get_series_observations(
+        observations = self.resolver_service.get_required_observations(
             series.series_id,
             end_date=observation_date,
             frequency=frequency,
             aggregation_method=aggregation_method,
             limit=1,
             sort_order="desc",
+            empty_result_message=(
+                f"No observations returned for {series.series_id} at "
+                f"{observation_date.isoformat() if observation_date is not None else 'the latest date'}."
+            ),
         )
-        if not observations:
-            date_text = observation_date.isoformat() if observation_date is not None else "the latest date"
-            raise ValueError(f"No observations returned for {series.series_id} at {date_text}.")
         return observations[0]
 
     @staticmethod

--- a/src/fred_query/services/relationship_service.py
+++ b/src/fred_query/services/relationship_service.py
@@ -7,6 +7,7 @@ from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata
 from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
 from fred_query.services.fred_client import FREDClient
+from fred_query.services.resolver_service import ResolverService
 from fred_query.services.transform_service import TransformService
 
 
@@ -17,11 +18,13 @@ class RelationshipAnalysisService:
         self,
         fred_client: FREDClient,
         *,
+        resolver_service: ResolverService | None = None,
         transform_service: TransformService | None = None,
         chart_service: ChartService | None = None,
         answer_service: AnswerService | None = None,
     ) -> None:
         self.fred_client = fred_client
+        self.resolver_service = resolver_service or ResolverService(fred_client)
         self.transform_service = transform_service or TransformService()
         self.chart_service = chart_service or ChartService()
         self.answer_service = answer_service or AnswerService()
@@ -61,50 +64,18 @@ class RelationshipAnalysisService:
         return f"Negative values mean {second_name} tends to lead {first_name} by {abs(lag)} {lag_unit}."
 
     def _resolve_series(self, intent: QueryIntent, index: int) -> tuple[ResolvedSeries, SeriesMetadata]:
-        explicit_series_id = self._series_id_for_index(intent, index)
-        if explicit_series_id:
-            metadata = self.fred_client.get_series_metadata(explicit_series_id)
-            return (
-                ResolvedSeries(
-                    series_id=metadata.series_id,
-                    title=metadata.title,
-                    geography="Unspecified",
-                    indicator=self._indicator_for_index(intent, index, metadata.title),
-                    units=metadata.units,
-                    frequency=metadata.frequency,
-                    seasonal_adjustment=metadata.seasonal_adjustment,
-                    score=1.0,
-                    resolution_reason=f"Used explicit series ID {metadata.series_id}.",
-                    source_url=metadata.source_url,
-                ),
-                metadata,
-            )
-
-        search_text = self._search_text_for_index(intent, index)
-        if not search_text:
-            raise ValueError("I need two resolvable series targets before I can run relationship analysis.")
-
-        matches = self.fred_client.search_series(search_text, limit=5)
-        if not matches:
-            raise ValueError(f"No FRED series matched search text '{search_text}'.")
-
-        search_match = matches[0]
-        metadata = self.fred_client.get_series_metadata(search_match.series_id)
-        return (
-            ResolvedSeries(
-                series_id=metadata.series_id,
-                title=metadata.title,
-                geography="Unspecified",
-                indicator=self._indicator_for_index(intent, index, search_text),
-                units=metadata.units,
-                frequency=metadata.frequency,
-                seasonal_adjustment=metadata.seasonal_adjustment,
-                score=0.8,
-                resolution_reason=f"Resolved the query via FRED search. Top match was {metadata.series_id}.",
-                source_url=metadata.source_url,
+        resolved, metadata, _ = self.resolver_service.resolve_series(
+            explicit_series_id=self._series_id_for_index(intent, index),
+            search_text=self._search_text_for_index(intent, index),
+            geography="Unspecified",
+            indicator=self._indicator_for_index(
+                intent,
+                index,
+                self._search_text_for_index(intent, index) or "unknown_indicator",
             ),
-            metadata,
+            no_target_message="I need two resolvable series targets before I can run relationship analysis.",
         )
+        return resolved, metadata
 
     def analyze(self, intent: QueryIntent) -> QueryResponse:
         response_intent = intent.model_copy(deep=True)
@@ -139,15 +110,13 @@ class RelationshipAnalysisService:
         analysis_units: list[str] = []
 
         for metadata in metadata_items:
-            observations = self.fred_client.get_series_observations(
+            observations = self.resolver_service.get_required_observations(
                 metadata.series_id,
                 start_date=start_date,
                 end_date=end_date,
                 frequency=frequency_code,
                 aggregation_method="avg",
             )
-            if not observations:
-                raise ValueError(f"No observations returned for {metadata.series_id}.")
 
             transformed, basis, units = self.transform_service.build_relationship_basis(
                 observations,

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from fred_query.schemas.resolved_series import ResolvedSeries
+from datetime import date
+
+from fred_query.schemas.analysis import ObservationPoint
+from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
 from fred_query.services.fred_client import FREDClient
 
 
@@ -88,26 +91,128 @@ class ResolverService:
 
         raise ValueError(f"Unrecognized state: {state_name}")
 
+    @staticmethod
+    def build_resolved_series(
+        metadata: SeriesMetadata,
+        *,
+        geography: str,
+        indicator: str,
+        score: float,
+        resolution_reason: str,
+    ) -> ResolvedSeries:
+        return ResolvedSeries(
+            series_id=metadata.series_id,
+            title=metadata.title,
+            geography=geography,
+            indicator=indicator,
+            units=metadata.units,
+            frequency=metadata.frequency,
+            seasonal_adjustment=metadata.seasonal_adjustment,
+            score=score,
+            resolution_reason=resolution_reason,
+            source_url=metadata.source_url,
+        )
+
+    def resolve_series(
+        self,
+        *,
+        explicit_series_id: str | None = None,
+        search_text: str | None = None,
+        geography: str = "Unspecified",
+        indicator: str = "unknown_indicator",
+        no_target_message: str | None = None,
+        search_resolution_reason: str | None = None,
+    ) -> tuple[ResolvedSeries, SeriesMetadata, SeriesSearchMatch | None]:
+        if explicit_series_id:
+            metadata = self.fred_client.get_series_metadata(explicit_series_id)
+            return (
+                self.build_resolved_series(
+                    metadata,
+                    geography=geography,
+                    indicator=indicator,
+                    score=1.0,
+                    resolution_reason=f"Used explicit series ID {metadata.series_id}.",
+                ),
+                metadata,
+                None,
+            )
+
+        if not search_text:
+            raise ValueError(no_target_message or "I need a resolvable series target before I can continue.")
+
+        matches = self.fred_client.search_series(search_text, limit=5)
+        if not matches:
+            raise ValueError(f"No FRED series matched search text '{search_text}'.")
+
+        search_match = matches[0]
+        metadata = self.fred_client.get_series_metadata(search_match.series_id)
+        resolution_reason = (
+            search_resolution_reason or "Resolved the query via FRED search. Top match was {series_id}."
+        ).format(
+            geography=geography,
+            indicator=indicator,
+            search_text=search_text,
+            series_id=metadata.series_id,
+            title=metadata.title,
+        )
+        return (
+            self.build_resolved_series(
+                metadata,
+                geography=geography,
+                indicator=indicator,
+                score=0.8,
+                resolution_reason=resolution_reason,
+            ),
+            metadata,
+            search_match,
+        )
+
+    def get_required_observations(
+        self,
+        series_id: str,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        frequency: str | None = None,
+        aggregation_method: str | None = None,
+        limit: int | None = None,
+        sort_order: str | None = None,
+        empty_result_message: str | None = None,
+    ) -> list[ObservationPoint]:
+        request_kwargs: dict[str, object] = {}
+        if start_date is not None:
+            request_kwargs["start_date"] = start_date
+        if end_date is not None:
+            request_kwargs["end_date"] = end_date
+        if frequency is not None:
+            request_kwargs["frequency"] = frequency
+        if aggregation_method is not None:
+            request_kwargs["aggregation_method"] = aggregation_method
+        if limit is not None:
+            request_kwargs["limit"] = limit
+        if sort_order is not None:
+            request_kwargs["sort_order"] = sort_order
+
+        observations = self.fred_client.get_series_observations(series_id, **request_kwargs)
+        if observations:
+            return observations
+        raise ValueError(empty_result_message or f"No observations returned for {series_id}.")
+
     def resolve_state_gdp_series(self, state_name: str) -> ResolvedSeries:
         state_code = self.resolve_state_code(state_name)
         canonical_state_name = STATE_CODE_TO_NAME[state_code]
         series_id = f"{state_code}RGSP"
         metadata = self.fred_client.get_series_metadata(series_id)
 
-        return ResolvedSeries(
-            series_id=series_id,
-            title=metadata.title,
+        return self.build_resolved_series(
+            metadata,
             geography=canonical_state_name,
             indicator="real_gdp",
-            units=metadata.units,
-            frequency=metadata.frequency,
-            seasonal_adjustment=metadata.seasonal_adjustment,
             score=1.0,
             resolution_reason=(
                 f"Resolved {state_name} to state code {state_code} and applied the FRED real GDP "
                 f"series pattern '{state_code}RGSP'."
             ),
-            source_url=metadata.source_url,
         )
 
     @staticmethod
@@ -132,41 +237,24 @@ class ResolverService:
             suffix, indicator = pattern
             series_id = f"{state_code}{suffix}"
             metadata = self.fred_client.get_series_metadata(series_id)
-            return ResolvedSeries(
-                series_id=series_id,
-                title=metadata.title,
+            return self.build_resolved_series(
+                metadata,
                 geography=canonical_state_name,
                 indicator=indicator,
-                units=metadata.units,
-                frequency=metadata.frequency,
-                seasonal_adjustment=metadata.seasonal_adjustment,
                 score=1.0,
                 resolution_reason=(
                     f"Resolved {state_name} to state code {state_code} and applied the FRED series pattern "
                     f"'{state_code}{suffix}' for {indicator.replace('_', ' ')}."
                 ),
-                source_url=metadata.source_url,
             )
 
         state_search_text = " ".join(part for part in [canonical_state_name, search_text or indicator_hint] if part)
-        matches = self.fred_client.search_series(state_search_text, limit=5)
-        if not matches:
-            raise ValueError(f"No FRED series matched search text '{state_search_text}'.")
-
-        search_match = matches[0]
-        metadata = self.fred_client.get_series_metadata(search_match.series_id)
-        return ResolvedSeries(
-            series_id=metadata.series_id,
-            title=metadata.title,
+        resolved, _, _ = self.resolve_series(
+            search_text=state_search_text,
             geography=canonical_state_name,
             indicator=indicator_hint.strip().lower().replace(" ", "_") or "unknown_indicator",
-            units=metadata.units,
-            frequency=metadata.frequency,
-            seasonal_adjustment=metadata.seasonal_adjustment,
-            score=0.8,
-            resolution_reason=(
-                f"Resolved {canonical_state_name} via FRED search. Top match for '{state_search_text}' was "
-                f"{metadata.series_id}."
+            search_resolution_reason=(
+                "Resolved {geography} via FRED search. Top match for '{search_text}' was {series_id}."
             ),
-            source_url=metadata.source_url,
         )
+        return resolved

--- a/src/fred_query/services/single_series_service.py
+++ b/src/fred_query/services/single_series_service.py
@@ -10,12 +10,12 @@ from fred_query.schemas.analysis import (
     QueryResponse,
     SeriesAnalysis,
 )
-from fred_query.schemas.resolved_series import ResolvedSeries
 from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
 from fred_query.services.fred_client import FREDClient
-from fred_query.services.transform_service import TransformService
+from fred_query.services.resolver_service import ResolverService
 from fred_query.schemas.intent import TransformType
+from fred_query.services.transform_service import TransformService
 
 
 class SingleSeriesLookupService:
@@ -27,11 +27,13 @@ class SingleSeriesLookupService:
         self,
         fred_client: FREDClient,
         *,
+        resolver_service: ResolverService | None = None,
         transform_service: TransformService | None = None,
         chart_service: ChartService | None = None,
         answer_service: AnswerService | None = None,
     ) -> None:
         self.fred_client = fred_client
+        self.resolver_service = resolver_service or ResolverService(fred_client)
         self.transform_service = transform_service or TransformService()
         self.chart_service = chart_service or ChartService()
         self.answer_service = answer_service or AnswerService()
@@ -125,32 +127,12 @@ class SingleSeriesLookupService:
         )
         normalize_chart = intent.normalization or intent.transform == TransformType.NORMALIZED_INDEX
 
-        if intent.series_id:
-            search_match = None
-            metadata = self.fred_client.get_series_metadata(intent.series_id)
-        else:
-            search_text = intent.search_text or " ".join(intent.indicators)
-            matches = self.fred_client.search_series(search_text, limit=5)
-            if not matches:
-                raise ValueError(f"No FRED series matched search text '{search_text}'.")
-            search_match = matches[0]
-            metadata = self.fred_client.get_series_metadata(search_match.series_id)
-
-        resolved_series = ResolvedSeries(
-            series_id=metadata.series_id,
-            title=metadata.title,
+        search_text = intent.search_text or " ".join(intent.indicators)
+        resolved_series, metadata, search_match = self.resolver_service.resolve_series(
+            explicit_series_id=intent.series_id,
+            search_text=search_text,
             geography=intent.geographies[0].name if intent.geographies else "Unspecified",
             indicator=intent.indicators[0] if intent.indicators else "unknown_indicator",
-            units=metadata.units,
-            frequency=metadata.frequency,
-            seasonal_adjustment=metadata.seasonal_adjustment,
-            score=1.0 if intent.series_id else 0.8,
-            resolution_reason=(
-                f"Used explicit series ID {metadata.series_id}."
-                if intent.series_id
-                else f"Resolved the query via FRED search. Top match was {metadata.series_id}."
-            ),
-            source_url=metadata.source_url,
         )
         response_intent.series_id = metadata.series_id
         if not response_intent.search_text:
@@ -175,13 +157,11 @@ class SingleSeriesLookupService:
             frequency=metadata.frequency,
         )
 
-        observations = self.fred_client.get_series_observations(
+        observations = self.resolver_service.get_required_observations(
             metadata.series_id,
             start_date=fetch_start_date,
             end_date=end_date,
         )
-        if not observations:
-            raise ValueError(f"No observations returned for {metadata.series_id}.")
 
         warnings: list[str] = []
         warnings.extend(transform_warnings)
@@ -243,13 +223,11 @@ class SingleSeriesLookupService:
                     frequency=metadata.frequency,
                 )
             try:
-                historical_observations = self.fred_client.get_series_observations(
+                historical_observations = self.resolver_service.get_required_observations(
                     metadata.series_id,
                     start_date=historical_fetch_start,
                     end_date=latest_date,
                 )
-                if not historical_observations:
-                    historical_observations = observations
             except Exception:
                 historical_observations = observations
                 if historical_fetch_start < observations[0].date:


### PR DESCRIPTION
The same “resolve metadata -> build ResolvedSeries -> score/reason -> fetch data” pattern is duplicated in single_series_service.py, relationship_service.py, and cross_section_service.py. To prevent duplication drifting in error messages, geography handling, and match quality, create a shared resolver/execution layer so each analysis service only owns its domain-specific math.