### PR TITLE
Promote typed analysis summaries through the API and UI

### DIFF
--- a/src/fred_query/api/follow_up_suggestions.py
+++ b/src/fred_query/api/follow_up_suggestions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import date
 
-from fred_query.schemas.analysis import QueryResponse, SeriesAnalysis
+from fred_query.schemas.analysis import FollowUpSuggestion, QueryResponse, SeriesAnalysis
 from fred_query.schemas.intent import CrossSectionScope, QueryIntent, TaskType, TransformType
 
 _MAX_SUGGESTIONS = 3
@@ -51,48 +51,60 @@ _SUBJECT_CANDIDATES: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 
-def build_follow_up_suggestions(response: QueryResponse) -> list[str]:
-    prompts: list[str] = []
+def build_follow_up_suggestions(response: QueryResponse) -> list[FollowUpSuggestion]:
+    prompts: list[FollowUpSuggestion] = []
     intent = response.intent
 
     if intent.task_type == TaskType.SINGLE_SERIES_LOOKUP:
-        _append_prompt(prompts, _single_series_compare_prompt(response))
-        _append_prompt(prompts, _single_series_transform_prompt(response))
-        _append_prompt(prompts, _single_series_peak_prompt(response))
-        _append_prompt(prompts, _extend_prompt(intent, response.analysis.coverage_start))
-        _append_prompt(prompts, _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end))
-        _append_prompt(prompts, _latest_prompt(intent, task_type=intent.task_type))
+        _append_prompt(prompts, "compare_alternative_subject", _single_series_compare_prompt(response))
+        _append_prompt(prompts, "toggle_transform", _single_series_transform_prompt(response))
+        _append_prompt(prompts, "historical_peak", _single_series_peak_prompt(response))
+        _append_prompt(prompts, "extend_range", _extend_prompt(intent, response.analysis.coverage_start))
+        _append_prompt(
+            prompts,
+            "recent_focus",
+            _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end),
+        )
+        _append_prompt(prompts, "latest_available", _latest_prompt(intent, task_type=intent.task_type))
         return prompts[:_MAX_SUGGESTIONS]
 
     if intent.task_type == TaskType.CROSS_SECTION:
-        _append_prompt(prompts, _cross_section_flip_prompt(intent, response))
-        _append_prompt(prompts, _cross_section_limit_prompt(intent, response))
-        _append_prompt(prompts, _cross_section_states_prompt(intent, response))
-        _append_prompt(prompts, _latest_prompt(intent, task_type=intent.task_type))
+        _append_prompt(prompts, "flip_ranking_direction", _cross_section_flip_prompt(intent, response))
+        _append_prompt(prompts, "change_ranking_limit", _cross_section_limit_prompt(intent, response))
+        _append_prompt(prompts, "expand_ranking_scope", _cross_section_states_prompt(intent, response))
+        _append_prompt(prompts, "latest_available", _latest_prompt(intent, task_type=intent.task_type))
         return prompts[:_MAX_SUGGESTIONS]
 
     if intent.task_type == TaskType.STATE_GDP_COMPARISON:
-        _append_prompt(prompts, _state_gdp_normalization_prompt(intent, response))
-        _append_prompt(prompts, _extend_prompt(intent, response.analysis.coverage_start))
-        _append_prompt(prompts, _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end))
-        _append_prompt(prompts, _latest_prompt(intent, task_type=intent.task_type))
+        _append_prompt(prompts, "toggle_normalization", _state_gdp_normalization_prompt(intent, response))
+        _append_prompt(prompts, "extend_range", _extend_prompt(intent, response.analysis.coverage_start))
+        _append_prompt(
+            prompts,
+            "recent_focus",
+            _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end),
+        )
+        _append_prompt(prompts, "latest_available", _latest_prompt(intent, task_type=intent.task_type))
         return prompts[:_MAX_SUGGESTIONS]
 
     if intent.task_type in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS):
-        _append_prompt(prompts, _comparison_swap_prompt(response))
-        _append_prompt(prompts, _comparison_transform_prompt(response))
-        _append_prompt(prompts, _extend_prompt(intent, response.analysis.coverage_start))
-        _append_prompt(prompts, _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end))
-        _append_prompt(prompts, _latest_prompt(intent, task_type=intent.task_type))
+        _append_prompt(prompts, "compare_alternative_subject", _comparison_swap_prompt(response))
+        _append_prompt(prompts, "toggle_transform", _comparison_transform_prompt(response))
+        _append_prompt(prompts, "extend_range", _extend_prompt(intent, response.analysis.coverage_start))
+        _append_prompt(
+            prompts,
+            "recent_focus",
+            _recent_focus_prompt(intent, response.analysis.coverage_start, response.analysis.coverage_end),
+        )
+        _append_prompt(prompts, "latest_available", _latest_prompt(intent, task_type=intent.task_type))
         return prompts[:_MAX_SUGGESTIONS]
 
     return []
 
 
-def _append_prompt(prompts: list[str], prompt: str | None) -> None:
+def _append_prompt(prompts: list[FollowUpSuggestion], kind: str, prompt: str | None) -> None:
     normalized = (prompt or "").strip()
-    if normalized and normalized not in prompts:
-        prompts.append(normalized)
+    if normalized and all(item.query != normalized for item in prompts):
+        prompts.append(FollowUpSuggestion(kind=kind, query=normalized, label=normalized))
 
 
 def _series_text(result: SeriesAnalysis) -> str:

--- a/src/fred_query/api/models.py
+++ b/src/fred_query/api/models.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator, model_validator
 
 from fred_query.api.follow_up_suggestions import build_follow_up_suggestions
-from fred_query.schemas.analysis import QueryResponse, RoutedQueryResponse, RoutedQueryStatus
+from fred_query.schemas.analysis import FollowUpSuggestion, QueryResponse, RoutedQueryResponse, RoutedQueryStatus
 from fred_query.schemas.intent import QueryIntent
 from fred_query.schemas.resolved_series import SeriesSearchMatch
 
@@ -101,7 +101,7 @@ class ApiQueryResponse(BaseModel):
     answer_text: str
     result: QueryResponse
     plotly_figure: dict[str, Any]
-    follow_up_suggestions: list[str] = Field(default_factory=list)
+    follow_up_suggestions: list[FollowUpSuggestion] = Field(default_factory=list)
 
     @classmethod
     def from_query_response(cls, response: QueryResponse) -> "ApiQueryResponse":
@@ -124,7 +124,7 @@ class ApiRoutedQueryResponse(BaseModel):
     candidate_series: list[SeriesSearchMatch] = Field(default_factory=list)
     result: QueryResponse | None = None
     plotly_figure: dict[str, Any] | None = None
-    follow_up_suggestions: list[str] = Field(default_factory=list)
+    follow_up_suggestions: list[FollowUpSuggestion] = Field(default_factory=list)
 
     @classmethod
     def from_routed_response(

--- a/src/fred_query/api/static/workspace-result-render.js
+++ b/src/fred_query/api/static/workspace-result-render.js
@@ -187,10 +187,27 @@ export function createResultRenderer(elements) {
         return value;
     }
 
-    function buildClarificationBadges(item) {
+    function buildClarificationOption(item) {
+        const typedOption = item?.clarification_option;
+        if (typedOption) {
+            return {
+                label: typedOption.label || item.title,
+                title: typedOption.title || item.title,
+                hint: typedOption.hint || item.selection_hint || "",
+                badges: Array.isArray(typedOption.badges)
+                    ? typedOption.badges.map((badge) => badge?.label).filter(Boolean)
+                    : [],
+            };
+        }
+
         const explicitBadges = Array.isArray(item.selection_badges) ? item.selection_badges.filter(Boolean) : [];
         if (explicitBadges.length > 0) {
-            return explicitBadges;
+            return {
+                label: item.selection_label || item.title,
+                title: item.title,
+                hint: item.selection_hint || "",
+                badges: explicitBadges,
+            };
         }
 
         const badges = [];
@@ -205,7 +222,12 @@ export function createResultRenderer(elements) {
         if (item.seasonal_adjustment) {
             badges.push(item.seasonal_adjustment);
         }
-        return badges.slice(0, 3);
+        return {
+            label: item.selection_label || item.title,
+            title: item.title,
+            hint: item.selection_hint || "",
+            badges: badges.slice(0, 3),
+        };
     }
 
     function renderIntent(intent) {
@@ -252,16 +274,23 @@ export function createResultRenderer(elements) {
         }
 
         followUpList.innerHTML = suggestions
-            .map((query) => `
+            .map((suggestion) => {
+                const query = typeof suggestion === "string" ? suggestion : suggestion?.query;
+                const label = typeof suggestion === "string" ? suggestion : (suggestion?.label || query);
+                if (!query) {
+                    return "";
+                }
+                return `
                 <button
                     type="button"
                     class="follow-up-suggestion"
                     data-query="${escapeHtml(query)}"
-                    title="${escapeHtml(query)}"
+                    title="${escapeHtml(label || query)}"
                 >
-                    ${escapeHtml(query)}
+                    ${escapeHtml(label || query)}
                 </button>
-            `)
+            `;
+            })
             .join("");
         setHidden(followUpPanel, false);
     }
@@ -276,9 +305,10 @@ export function createResultRenderer(elements) {
         metricsGrid.innerHTML = metrics
             .map((metric) => {
                 const unit = metric.unit ? ` ${escapeHtml(metric.unit)}` : "";
+                const label = metric.label || humanize(metric.name);
                 return `
                     <article class="metric-card">
-                        <p class="metric-card-label">${escapeHtml(humanize(metric.name))}</p>
+                        <p class="metric-card-label">${escapeHtml(label)}</p>
                         <p class="metric-card-value">${escapeHtml(formatValue(metric.value))}${unit}</p>
                         ${metric.description ? `<p class="metric-card-description">${escapeHtml(metric.description)}</p>` : ""}
                     </article>
@@ -507,9 +537,10 @@ export function createResultRenderer(elements) {
         clarificationQuestion.textContent = revision.response.answer_text || "Pick the series you meant.";
         clarificationOptions.innerHTML = candidates
             .map((item) => {
-                const badges = buildClarificationBadges(item);
-                const label = item.selection_label || item.title;
-                const showOfficialTitle = Boolean(item.selection_label && item.selection_label !== item.title);
+                const option = buildClarificationOption(item);
+                const badges = option.badges;
+                const label = option.label || item.title;
+                const showOfficialTitle = Boolean(option.title && label && label !== option.title);
                 return `
                     <button
                         type="button"
@@ -520,13 +551,13 @@ export function createResultRenderer(elements) {
                             <span class="clarification-option-label">${escapeHtml(label)}</span>
                             <span class="clarification-option-series-id">FRED: ${escapeHtml(item.series_id)}</span>
                         </div>
-                        ${showOfficialTitle ? `<span class="clarification-option-title">${escapeHtml(item.title)}</span>` : ""}
+                        ${showOfficialTitle ? `<span class="clarification-option-title">${escapeHtml(option.title)}</span>` : ""}
                         ${badges.length ? `
                             <div class="clarification-option-badges">
                                 ${badges.map((badge) => `<span class="clarification-option-badge">${escapeHtml(badge)}</span>`).join("")}
                             </div>
                         ` : ""}
-                        ${item.selection_hint ? `<span class="clarification-option-hint">${escapeHtml(item.selection_hint)}</span>` : ""}
+                        ${option.hint ? `<span class="clarification-option-hint">${escapeHtml(option.hint)}</span>` : ""}
                     </button>
                 `;
             })

--- a/src/fred_query/schemas/__init__.py
+++ b/src/fred_query/schemas/__init__.py
@@ -1,9 +1,12 @@
 from fred_query.schemas.analysis import (
     AnalysisResult,
+    CrossSectionSummary,
     DerivedMetric,
+    FollowUpSuggestion,
     HistoricalSeriesContext,
     ObservationPoint,
     QueryResponse,
+    RelationshipSummary,
     RoutedQueryResponse,
     RoutedQueryStatus,
     SeriesAnalysis,
@@ -18,7 +21,13 @@ from fred_query.schemas.intent import (
     TaskType,
     TransformType,
 )
-from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
+from fred_query.schemas.resolved_series import (
+    ClarificationBadge,
+    ClarificationOption,
+    ResolvedSeries,
+    SeriesMetadata,
+    SeriesSearchMatch,
+)
 
 __all__ = [
     "AnalysisResult",
@@ -27,8 +36,10 @@ __all__ = [
     "ChartTrace",
     "ComparisonMode",
     "CrossSectionScope",
+    "CrossSectionSummary",
     "DateSpanAnnotation",
     "DerivedMetric",
+    "FollowUpSuggestion",
     "Geography",
     "GeographyType",
     "HistoricalSeriesContext",
@@ -36,10 +47,13 @@ __all__ = [
     "ObservationPoint",
     "QueryIntent",
     "QueryResponse",
+    "RelationshipSummary",
     "ResolvedSeries",
     "RoutedQueryResponse",
     "RoutedQueryStatus",
     "SeriesAnalysis",
+    "ClarificationBadge",
+    "ClarificationOption",
     "SeriesMetadata",
     "SeriesSearchMatch",
     "TaskType",

--- a/src/fred_query/schemas/analysis.py
+++ b/src/fred_query/schemas/analysis.py
@@ -23,6 +23,7 @@ class DerivedMetric(BaseModel):
     name: str
     value: float | int | str
     unit: str | None = None
+    label: str | None = None
     description: str | None = None
 
 
@@ -38,6 +39,41 @@ class HistoricalSeriesContext(BaseModel):
     min_date: date | None = None
     max_value: float | None = None
     max_date: date | None = None
+
+
+class FollowUpSuggestion(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    kind: str
+    query: str
+    label: str | None = None
+
+
+class RelationshipSummary(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    analysis_basis: str | None = None
+    common_frequency: str | None = None
+    overlap_observations: int | None = None
+    same_period_correlation: float | None = None
+    regression_slope: float | None = None
+    strongest_lag_periods: int | None = None
+    strongest_lag_unit: str | None = None
+    strongest_lag_correlation: float | None = None
+    strongest_lag_observations: int | None = None
+
+
+class CrossSectionSummary(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    snapshot_basis: str
+    resolved_series_count: int
+    displayed_series_count: int
+    display_selection_basis: str
+    rank_order: str
+    leader_label: str
+    leader_value: float | None = None
+    leader_unit: str | None = None
 
 
 class SeriesAnalysis(BaseModel):
@@ -60,6 +96,8 @@ class AnalysisResult(BaseModel):
 
     series_results: list[SeriesAnalysis] = Field(default_factory=list)
     derived_metrics: list[DerivedMetric] = Field(default_factory=list)
+    relationship_summary: RelationshipSummary | None = None
+    cross_section_summary: CrossSectionSummary | None = None
     warnings: list[str] = Field(default_factory=list)
     latest_observation_date: date | None = None
     coverage_start: date | None = None

--- a/src/fred_query/schemas/resolved_series.py
+++ b/src/fred_query/schemas/resolved_series.py
@@ -3,11 +3,28 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class ClarificationBadge(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    kind: str
+    label: str
+
+
+class ClarificationOption(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    label: str | None = None
+    title: str | None = None
+    hint: str | None = None
+    badges: list[ClarificationBadge] = Field(default_factory=list)
+
+
 class SeriesSearchMatch(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     series_id: str
     title: str
+    clarification_option: ClarificationOption | None = None
     selection_label: str | None = None
     selection_hint: str | None = None
     selection_badges: list[str] = Field(default_factory=list)

--- a/src/fred_query/services/answer_service.py
+++ b/src/fred_query/services/answer_service.py
@@ -245,13 +245,30 @@ class AnswerService:
         first, second = analysis.series_results
         start_year = analysis.coverage_start.year if analysis.coverage_start else "the requested start"
         end_year = analysis.coverage_end.year if analysis.coverage_end else "the latest available year"
-        frequency = self._metric_value(analysis, "common_frequency")
-        basis = self._metric_value(analysis, "analysis_basis")
-        overlap = self._metric_value(analysis, "overlap_observations")
-        same_period_correlation = self._metric_value(analysis, "same_period_correlation")
-        strongest_lag = self._metric_value(analysis, "strongest_lag_periods")
-        strongest_lag_correlation = self._metric_value(analysis, "strongest_lag_correlation")
-        lag_unit = self._metric_unit(analysis, "strongest_lag_periods") or "periods"
+        summary = analysis.relationship_summary
+        frequency = summary.common_frequency if summary is not None else self._metric_value(analysis, "common_frequency")
+        basis = summary.analysis_basis if summary is not None else self._metric_value(analysis, "analysis_basis")
+        overlap = (
+            summary.overlap_observations if summary is not None else self._metric_value(analysis, "overlap_observations")
+        )
+        same_period_correlation = (
+            summary.same_period_correlation
+            if summary is not None
+            else self._metric_value(analysis, "same_period_correlation")
+        )
+        strongest_lag = (
+            summary.strongest_lag_periods if summary is not None else self._metric_value(analysis, "strongest_lag_periods")
+        )
+        strongest_lag_correlation = (
+            summary.strongest_lag_correlation
+            if summary is not None
+            else self._metric_value(analysis, "strongest_lag_correlation")
+        )
+        lag_unit = (
+            summary.strongest_lag_unit
+            if summary is not None and summary.strongest_lag_unit
+            else self._metric_unit(analysis, "strongest_lag_periods") or "periods"
+        )
 
         parts = [
             f"Analyzed the relationship between {first.series.title} and {second.series.title} from {start_year} to {end_year}.",
@@ -280,11 +297,24 @@ class AnswerService:
 
     def write_cross_section(self, analysis: AnalysisResult, *, intent: QueryIntent) -> str:
         leader = analysis.series_results[0]
-        snapshot_basis = self._metric_value(analysis, "snapshot_basis") or "Latest available observation"
-        displayed_count = self._metric_value(analysis, "displayed_series_count")
-        resolved_count = self._metric_value(analysis, "resolved_series_count")
-        display_selection_basis = self._metric_value(analysis, "display_selection_basis")
-        rank_label = "highest" if intent.sort_descending else "lowest"
+        summary = analysis.cross_section_summary
+        snapshot_basis = (
+            summary.snapshot_basis
+            if summary is not None
+            else self._metric_value(analysis, "snapshot_basis") or "Latest available observation"
+        )
+        displayed_count = (
+            summary.displayed_series_count if summary is not None else self._metric_value(analysis, "displayed_series_count")
+        )
+        resolved_count = (
+            summary.resolved_series_count if summary is not None else self._metric_value(analysis, "resolved_series_count")
+        )
+        display_selection_basis = (
+            summary.display_selection_basis
+            if summary is not None
+            else self._metric_value(analysis, "display_selection_basis")
+        )
+        rank_label = summary.rank_order if summary is not None else ("highest" if intent.sort_descending else "lowest")
 
         if int(resolved_count or len(analysis.series_results)) == 1:
             parts = [

--- a/src/fred_query/services/cross_section_service.py
+++ b/src/fred_query/services/cross_section_service.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from datetime import date
 
-from fred_query.schemas.analysis import AnalysisResult, DerivedMetric, ObservationPoint, QueryResponse, SeriesAnalysis
+from fred_query.schemas.analysis import (
+    AnalysisResult,
+    CrossSectionSummary,
+    DerivedMetric,
+    ObservationPoint,
+    QueryResponse,
+    SeriesAnalysis,
+)
 from fred_query.schemas.intent import ComparisonMode, CrossSectionScope, GeographyType, QueryIntent
 from fred_query.schemas.resolved_series import ResolvedSeries
 from fred_query.services.answer_service import AnswerService
@@ -256,28 +263,33 @@ class CrossSectionService:
         derived_metrics = [
             DerivedMetric(
                 name="resolved_series_count",
+                label="Resolved series count",
                 value=len(ranked_results),
                 unit="series",
                 description="Series included in the ranked cross-section before any display cap was applied.",
             ),
             DerivedMetric(
                 name="displayed_series_count",
+                label="Displayed series count",
                 value=len(displayed_results),
                 unit="series",
                 description="Series shown in the ranked bar chart.",
             ),
             DerivedMetric(
                 name="display_selection_basis",
+                label="Display selection basis",
                 value=display_selection_basis,
                 description="Whether the displayed slice came from an explicit request, a contextual default, or the full result set.",
             ),
             DerivedMetric(
                 name="snapshot_basis",
+                label="Snapshot basis",
                 value=snapshot_basis,
                 description="Observation timing used for the cross-section snapshot.",
             ),
             DerivedMetric(
                 name="rank_leader",
+                label="Rank leader",
                 value=self._display_label(leader.series),
                 description=f"The geography or series with the {rank_label} observed value in the ranked snapshot.",
             ),
@@ -287,6 +299,7 @@ class CrossSectionService:
             derived_metrics.append(
                 DerivedMetric(
                     name="rank_leader_value",
+                    label="Rank leader value",
                     value=round(leader.latest_value, 4),
                     unit=leader.series.units,
                     description=f"The {rank_label} observed value in the ranked snapshot.",
@@ -297,6 +310,16 @@ class CrossSectionService:
         analysis = AnalysisResult(
             series_results=displayed_results,
             derived_metrics=derived_metrics,
+            cross_section_summary=CrossSectionSummary(
+                snapshot_basis=snapshot_basis,
+                resolved_series_count=len(ranked_results),
+                displayed_series_count=len(displayed_results),
+                display_selection_basis=display_selection_basis,
+                rank_order=rank_label,
+                leader_label=self._display_label(leader.series),
+                leader_value=round(leader.latest_value, 4) if leader.latest_value is not None else None,
+                leader_unit=leader.series.units if leader.latest_value is not None else None,
+            ),
             warnings=warnings,
             latest_observation_date=max(coverage_dates) if coverage_dates else None,
             coverage_start=min(coverage_dates) if coverage_dates else None,

--- a/src/fred_query/services/natural_language_query_service.py
+++ b/src/fred_query/services/natural_language_query_service.py
@@ -6,7 +6,7 @@ import re
 
 from fred_query.schemas.analysis import RoutedQueryResponse, RoutedQueryStatus
 from fred_query.schemas.intent import ComparisonMode, QueryIntent, TaskType, TransformType
-from fred_query.schemas.resolved_series import SeriesSearchMatch
+from fred_query.schemas.resolved_series import ClarificationBadge, ClarificationOption, SeriesSearchMatch
 from fred_query.services.comparison_service import StateGDPComparisonService
 from fred_query.services.cross_section_service import CrossSectionService
 from fred_query.services.fred_client import FREDClient
@@ -554,26 +554,26 @@ class NaturalLanguageQueryService:
         return None
 
     @classmethod
-    def _selection_badges_for_candidate(cls, candidate: SeriesSearchMatch) -> list[str]:
-        badges: list[str] = []
+    def _selection_badges_for_candidate(cls, candidate: SeriesSearchMatch) -> list[ClarificationBadge]:
+        badges: list[ClarificationBadge] = []
         frequency_label = cls._FREQUENCY_LABELS.get((candidate.frequency or "").upper())
         if frequency_label:
-            badges.append(frequency_label)
+            badges.append(ClarificationBadge(kind="frequency", label=frequency_label))
 
         units_text = cls._normalized_text(candidate.units)
         if "6-month annualized" in units_text:
-            badges.append("6M annualized")
+            badges.append(ClarificationBadge(kind="units", label="6M annualized"))
         elif "% chg. from yr. ago" in units_text or "percent change from year ago" in units_text:
-            badges.append("YoY rate")
+            badges.append(ClarificationBadge(kind="units", label="YoY rate"))
         elif "annual rate" in units_text or "annualized" in units_text:
-            badges.append("Annualized rate")
+            badges.append(ClarificationBadge(kind="units", label="Annualized rate"))
         elif "index" in units_text:
-            badges.append("Index level")
+            badges.append(ClarificationBadge(kind="units", label="Index level"))
         elif "percent" in units_text:
-            badges.append("Percent")
+            badges.append(ClarificationBadge(kind="units", label="Percent"))
 
         if candidate.seasonal_adjustment:
-            badges.append(candidate.seasonal_adjustment)
+            badges.append(ClarificationBadge(kind="seasonal_adjustment", label=candidate.seasonal_adjustment))
 
         return badges[:3]
 
@@ -587,12 +587,23 @@ class NaturalLanguageQueryService:
         return [
             candidate.model_copy(
                 update={
+                    "clarification_option": ClarificationOption(
+                        label=self._selection_label_for_candidate(candidate),
+                        title=candidate.title,
+                        hint=self._selection_hint_for_candidate(
+                            candidate,
+                            search_text=search_text,
+                        ),
+                        badges=self._selection_badges_for_candidate(candidate),
+                    ),
                     "selection_label": self._selection_label_for_candidate(candidate),
                     "selection_hint": self._selection_hint_for_candidate(
                         candidate,
                         search_text=search_text,
                     ),
-                    "selection_badges": self._selection_badges_for_candidate(candidate),
+                    "selection_badges": [
+                        badge.label for badge in self._selection_badges_for_candidate(candidate)
+                    ],
                 }
             )
             for candidate in candidates

--- a/src/fred_query/services/relationship_service.py
+++ b/src/fred_query/services/relationship_service.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-from fred_query.schemas.analysis import AnalysisResult, DerivedMetric, QueryIntent, QueryResponse, SeriesAnalysis
+from fred_query.schemas.analysis import (
+    AnalysisResult,
+    DerivedMetric,
+    QueryIntent,
+    QueryResponse,
+    RelationshipSummary,
+    SeriesAnalysis,
+)
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata
 from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
@@ -220,16 +227,19 @@ class RelationshipAnalysisService:
         derived_metrics = [
             DerivedMetric(
                 name="analysis_basis",
+                label="Analysis basis",
                 value=basis_summary,
                 description="Transformation used to make the pairwise comparison more stable and interpretable.",
             ),
             DerivedMetric(
                 name="common_frequency",
+                label="Common frequency",
                 value=frequency_label,
                 description="Frequency used to align the two series before estimating the relationship.",
             ),
             DerivedMetric(
                 name="overlap_observations",
+                label="Overlap observations",
                 value=len(aligned_first),
                 unit="observations",
                 description="Number of aligned observations used in the same-period relationship estimate.",
@@ -240,6 +250,7 @@ class RelationshipAnalysisService:
             derived_metrics.append(
                 DerivedMetric(
                     name="same_period_correlation",
+                    label="Same-period correlation",
                     value=round(same_period_correlation, 4),
                     description="Pearson correlation on the aligned analysis basis in the same period.",
                 )
@@ -249,6 +260,7 @@ class RelationshipAnalysisService:
             derived_metrics.append(
                 DerivedMetric(
                     name="regression_slope",
+                    label="Regression slope",
                     value=round(regression_slope, 4),
                     description=(
                         f"Simple linear slope of {resolved_series[1].series_id} on {resolved_series[0].series_id} "
@@ -262,6 +274,7 @@ class RelationshipAnalysisService:
                 [
                     DerivedMetric(
                         name="strongest_lag_periods",
+                        label="Strongest lag",
                         value=best_lag,
                         unit=lag_unit,
                         description=self._lag_description(
@@ -273,6 +286,7 @@ class RelationshipAnalysisService:
                     ),
                     DerivedMetric(
                         name="strongest_lag_correlation",
+                        label="Strongest lag correlation",
                         value=round(best_lag_correlation, 4),
                         description=(
                             f"Absolute strongest correlation in the tested lead-lag window using {best_lag_samples} "
@@ -285,6 +299,21 @@ class RelationshipAnalysisService:
         analysis = AnalysisResult(
             series_results=series_results,
             derived_metrics=derived_metrics,
+            relationship_summary=RelationshipSummary(
+                analysis_basis=basis_summary,
+                common_frequency=frequency_label,
+                overlap_observations=len(aligned_first),
+                same_period_correlation=round(same_period_correlation, 4)
+                if same_period_correlation is not None
+                else None,
+                regression_slope=round(regression_slope, 4) if regression_slope is not None else None,
+                strongest_lag_periods=best_lag,
+                strongest_lag_unit=lag_unit if best_lag is not None else None,
+                strongest_lag_correlation=round(best_lag_correlation, 4)
+                if best_lag_correlation is not None
+                else None,
+                strongest_lag_observations=best_lag_samples,
+            ),
             warnings=warnings,
             latest_observation_date=max(latest_dates),
             coverage_start=aligned_first[0].date,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,9 +7,11 @@ from fastapi.testclient import TestClient
 
 from fred_query.api.app import (
     app,
+    get_app_settings,
     get_natural_language_query_service,
     get_state_gdp_comparison_service,
 )
+from fred_query.config import Settings
 from fred_query.errors import ConfigurationError
 from fred_query.schemas.analysis import (
     AnalysisResult,
@@ -20,7 +22,7 @@ from fred_query.schemas.analysis import (
 )
 from fred_query.schemas.chart import AxisSpec, ChartSpec, ChartTrace
 from fred_query.schemas.intent import ComparisonMode, Geography, GeographyType, QueryIntent, TaskType, TransformType
-from fred_query.schemas.resolved_series import ResolvedSeries, SeriesSearchMatch
+from fred_query.schemas.resolved_series import ClarificationBadge, ClarificationOption, ResolvedSeries, SeriesSearchMatch
 from fred_query.services import FREDAPIError, QuerySession
 
 
@@ -141,6 +143,10 @@ class _FailingStateGDPComparisonService:
 class APITest(unittest.TestCase):
     def setUp(self) -> None:
         app.dependency_overrides.clear()
+        app.dependency_overrides[get_app_settings] = lambda: Settings(
+            fred_api_key="test-fred-key",
+            openai_api_key="test-openai-key",
+        )
         self.client = TestClient(app)
 
     def tearDown(self) -> None:
@@ -189,8 +195,9 @@ class APITest(unittest.TestCase):
         self.assertEqual(payload["plotly_figure"]["layout"]["title"]["text"], "Real GDP Comparison: California vs Texas")
         self.assertIn(
             "Show Real GDP: California and Real GDP: Texas in reported GDP levels instead",
-            payload["follow_up_suggestions"],
+            [item["query"] for item in payload["follow_up_suggestions"]],
         )
+        self.assertEqual(payload["follow_up_suggestions"][0]["kind"], "toggle_normalization")
 
     def test_ask_forwards_selected_series_id(self) -> None:
         routed = RoutedQueryResponse(
@@ -243,6 +250,15 @@ class APITest(unittest.TestCase):
                 SeriesSearchMatch(
                     series_id="CPIAUCSL",
                     title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                    clarification_option=ClarificationOption(
+                        label="Headline CPI",
+                        title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                        hint="Pick this if you want CPI, the broad consumer inflation measure most people mean by 'inflation'.",
+                        badges=[
+                            ClarificationBadge(kind="frequency", label="Monthly"),
+                            ClarificationBadge(kind="units", label="Index level"),
+                        ],
+                    ),
                     selection_label="Headline CPI",
                     selection_hint="Pick this if you want CPI, the broad consumer inflation measure most people mean by 'inflation'.",
                     selection_badges=["Monthly", "Index level"],
@@ -261,6 +277,11 @@ class APITest(unittest.TestCase):
         self.assertEqual(payload["candidate_series"][0]["series_id"], "CPIAUCSL")
         self.assertEqual(payload["candidate_series"][0]["selection_label"], "Headline CPI")
         self.assertIn("Pick this if you want CPI", payload["candidate_series"][0]["selection_hint"])
+        self.assertEqual(payload["candidate_series"][0]["clarification_option"]["label"], "Headline CPI")
+        self.assertEqual(
+            [item["label"] for item in payload["candidate_series"][0]["clarification_option"]["badges"]],
+            ["Monthly", "Index level"],
+        )
 
     def test_ask_reuses_session_id_for_follow_up(self) -> None:
         routed = RoutedQueryResponse(
@@ -345,7 +366,7 @@ class APITest(unittest.TestCase):
         self.assertEqual(payload["plotly_figure"]["layout"]["title"]["text"], "Real GDP Comparison: California vs Texas")
         self.assertIn(
             "Show Real GDP: California and Real GDP: Texas in reported GDP levels instead",
-            payload["follow_up_suggestions"],
+            [item["query"] for item in payload["follow_up_suggestions"]],
         )
 
     def test_ask_blank_query_returns_validation_error(self) -> None:

--- a/tests/test_cross_section_service.py
+++ b/tests/test_cross_section_service.py
@@ -120,6 +120,8 @@ class CrossSectionServiceTest(unittest.TestCase):
         )
         self.assertEqual(response.chart.series[0].x_categories, ["Nevada", "California"])
         self.assertEqual(response.chart.series[0].y, [6.5, 5.0])
+        self.assertIsNotNone(response.analysis.cross_section_summary)
+        self.assertEqual(response.analysis.cross_section_summary.leader_label, "Nevada")
         self.assertIn("Nevada ranks highest", response.answer_text)
         observation_requests = [item for item in requests if item.get("series_id") in {"CAUR", "TXUR", "NVUR"} and item.get("sort_order") == "desc"]
         self.assertEqual(len(observation_requests), 3)
@@ -163,6 +165,7 @@ class CrossSectionServiceTest(unittest.TestCase):
         self.assertEqual(len(response.analysis.series_results), 10)
         self.assertEqual(response.intent.rank_limit, 10)
         self.assertEqual(response.analysis.series_results[0].series.geography, "Nevada")
+        self.assertEqual(response.analysis.cross_section_summary.display_selection_basis, "comparison_context")
         self.assertEqual(response.chart.series[0].x_categories[0], "Nevada")
         self.assertIn("comparison context around the leader", response.answer_text)
         self.assertIn("Showing 10 of 12 series for comparison context.", response.chart.subtitle or "")
@@ -185,6 +188,7 @@ class CrossSectionServiceTest(unittest.TestCase):
         self.assertEqual(response.chart.series[0].x_categories, ["CPIAUCSL"])
         self.assertEqual(response.chart.series[0].y, [300.54])
         self.assertEqual(response.analysis.series_results[0].latest_observation_date, date(2023, 1, 1))
+        self.assertEqual(response.analysis.cross_section_summary.resolved_series_count, 1)
         self.assertIn("2023-01-01", response.answer_text)
 
 

--- a/tests/test_follow_up_suggestions.py
+++ b/tests/test_follow_up_suggestions.py
@@ -90,7 +90,7 @@ class FollowUpSuggestionsTest(unittest.TestCase):
         suggestions = build_follow_up_suggestions(response)
 
         self.assertEqual(
-            suggestions,
+            [item.query for item in suggestions],
             [
                 "Compare United States Unemployment Rate to inflation over the same period",
                 "Show United States Unemployment Rate as year-over-year change",
@@ -141,7 +141,7 @@ class FollowUpSuggestionsTest(unittest.TestCase):
         suggestions = build_follow_up_suggestions(response)
 
         self.assertEqual(
-            suggestions,
+            [item.query for item in suggestions],
             [
                 "Compare Global Crude Oil Prices: Brent - Europe to unemployment instead",
                 "Show Global Crude Oil Prices: Brent - Europe and United States Consumer Price Index for All Urban Consumers as year-over-year change",
@@ -192,7 +192,7 @@ class FollowUpSuggestionsTest(unittest.TestCase):
         suggestions = build_follow_up_suggestions(response)
 
         self.assertEqual(
-            suggestions,
+            [item.query for item in suggestions],
             [
                 "Rank the bottom 10 states by unemployment rate instead",
                 "Rank the top 5 states by unemployment rate",
@@ -252,7 +252,7 @@ class FollowUpSuggestionsTest(unittest.TestCase):
         api_response = ApiQueryResponse.from_query_response(response)
 
         self.assertEqual(
-            api_response.follow_up_suggestions,
+            [item.query for item in api_response.follow_up_suggestions],
             [
                 "Show Real GDP: California and Real GDP: Texas in reported GDP levels instead",
                 "Extend this back to 2000",
@@ -297,7 +297,7 @@ class FollowUpSuggestionsTest(unittest.TestCase):
 
         self.assertIn(
             "Show United States Consumer Price Index for All Urban Consumers in reported levels instead",
-            suggestions,
+            [item.query for item in suggestions],
         )
 
 

--- a/tests/test_natural_language_query_service.py
+++ b/tests/test_natural_language_query_service.py
@@ -512,6 +512,8 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         )
         self.assertIn("Pick this if you want CPI", response.candidate_series[0].selection_hint or "")
         self.assertIn("Pick this if you want PCE", response.candidate_series[1].selection_hint or "")
+        self.assertEqual(response.candidate_series[0].clarification_option.label, "Headline CPI")
+        self.assertEqual(response.candidate_series[1].clarification_option.label, "Headline PCE")
 
     def test_clarification_candidates_fall_back_to_ranked_matches_when_example_scores_are_weak(self) -> None:
         intent = QueryIntent(
@@ -570,6 +572,10 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         )
         self.assertEqual(
             [candidate.selection_label for candidate in response.candidate_series],
+            ["Headline CPI", "Headline PCE", "Trimmed Mean PCE"],
+        )
+        self.assertEqual(
+            [candidate.clarification_option.label for candidate in response.candidate_series],
             ["Headline CPI", "Headline PCE", "Trimmed Mean PCE"],
         )
         self.assertEqual(

--- a/tests/test_relationship_service.py
+++ b/tests/test_relationship_service.py
@@ -101,6 +101,8 @@ class RelationshipAnalysisServiceTest(unittest.TestCase):
         metric_names = {metric.name for metric in response.analysis.derived_metrics}
         self.assertIn("same_period_correlation", metric_names)
         self.assertIn("strongest_lag_periods", metric_names)
+        self.assertIsNotNone(response.analysis.relationship_summary)
+        self.assertEqual(response.analysis.relationship_summary.common_frequency, "Monthly")
         self.assertIn("association estimate", response.answer_text.lower())
         self.assertIn("DCOILBRENTEU", response.answer_text)
         self.assertEqual(client.requests[0], ("DCOILBRENTEU", "m", "avg"))


### PR DESCRIPTION
## What changed
- Added typed API/schema models for prepared semantics, including `FollowUpSuggestion`, `RelationshipSummary`, `CrossSectionSummary`, `ClarificationOption`, and `ClarificationBadge`.
- Updated the relationship and cross-section services to populate those summaries directly instead of relying only on generic `DerivedMetric.name` keys.
- Updated `AnswerService` to read typed summaries first, so answer generation no longer needs to reconstruct relationship and cross-section meaning from stringly metric names.
- Changed follow-up suggestions from plain strings to structured objects with a `kind`, `query`, and label-ready text.
- Attached typed clarification metadata to `SeriesSearchMatch` so the frontend can render labels, hints, and badges from backend-prepared semantics.
- Updated the workspace result renderer to consume typed follow-up suggestions, clarification options, and metric labels directly while preserving compatibility with older shapes.
- Extended the test suite to cover the new contract end to end across API, query routing, relationship analysis, cross-section analysis, and follow-up suggestion generation.

## Why
The branch task was to replace stringly-typed analysis and UI contracts with typed summaries.

Before this change, backend and frontend code were repeatedly recovering meaning from loosely structured fields:
- `AnswerService` inferred relationship and cross-section semantics by looking up `DerivedMetric.name` values.
- Follow-up suggestion behavior was encoded as plain strings with no typed intent metadata.
- The frontend re-derived clarification badges and metric labels from raw series fields even though the backend had already computed equivalent metadata.

This made the contract harder to read, easier to break, and forced UI code to duplicate backend interpretation logic. The new typed summaries move that meaning into the API contract so consumers render prepared semantics instead of reconstructing them.

## Important implementation details
- `DerivedMetric` now supports an explicit `label`, so display names no longer need to be inferred from metric identifiers in the UI.
- Relationship analysis still emits derived metrics for display, but now also emits a typed `relationship_summary` for narrative and contract-level consumers.
- Cross-section analysis follows the same pattern with a typed `cross_section_summary` alongside display metrics.
- Clarification candidate enrichment in `NaturalLanguageQueryService` now produces both the new typed `clarification_option` payload and the legacy `selection_*` fields, which keeps the transition low-risk.
- The frontend renderer was updated to prefer the typed fields but still fall back to the older shape when needed.
- API response models were updated so follow-up suggestions are now serialized as typed objects rather than raw strings.

## Validation
- Ran `python -m pytest`
- Result: `62 passed`
