### PR TITLE
Add QueryPlan layer above task routing (Vibe Kanban)

### DIFF
--- a/src/fred_query/schemas/__init__.py
+++ b/src/fred_query/schemas/__init__.py
@@ -17,8 +17,13 @@ from fred_query.schemas.intent import (
     CrossSectionScope,
     Geography,
     GeographyType,
+    QueryOperator,
+    QueryOutputMode,
+    QueryPlan,
+    QueryTimeScope,
     QueryIntent,
     TaskType,
+    TimeScopeKind,
     TransformType,
 )
 from fred_query.schemas.resolved_series import (
@@ -45,8 +50,12 @@ __all__ = [
     "HistoricalSeriesContext",
     "LineStyle",
     "ObservationPoint",
+    "QueryOperator",
     "QueryIntent",
+    "QueryOutputMode",
+    "QueryPlan",
     "QueryResponse",
+    "QueryTimeScope",
     "RelationshipSummary",
     "ResolvedSeries",
     "RoutedQueryResponse",
@@ -57,5 +66,6 @@ __all__ = [
     "SeriesMetadata",
     "SeriesSearchMatch",
     "TaskType",
+    "TimeScopeKind",
     "TransformType",
 ]

--- a/src/fred_query/schemas/intent.py
+++ b/src/fred_query/schemas/intent.py
@@ -218,10 +218,11 @@ class QueryIntent(BaseModel):
         return QueryOutputMode.TIME_SERIES
 
     def _is_state_gdp_comparison_plan(self, query_plan: QueryPlan) -> bool:
-        if self.task_type == TaskType.STATE_GDP_COMPARISON:
-            return True
         if len(self.geographies) != 2:
             return False
         if any(item.geography_type != GeographyType.STATE for item in self.geographies):
             return False
-        return any("gdp" in subject.lower() for subject in query_plan.subjects)
+        subjects = [subject.strip().lower() for subject in query_plan.subjects if subject and subject.strip()]
+        if not subjects:
+            return self.task_type == TaskType.STATE_GDP_COMPARISON
+        return all("gdp" in subject for subject in subjects)

--- a/src/fred_query/schemas/intent.py
+++ b/src/fred_query/schemas/intent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class TaskType(str, Enum):
@@ -46,6 +46,45 @@ class CrossSectionScope(str, Enum):
     STATES = "states"
 
 
+class QueryOperator(str, Enum):
+    LOOKUP = "lookup"
+    COMPARE = "compare"
+    RANK = "rank"
+    ANALYZE_RELATIONSHIP = "analyze_relationship"
+
+
+class QueryOutputMode(str, Enum):
+    TIME_SERIES = "time_series"
+    CROSS_SECTION = "cross_section"
+    RELATIONSHIP = "relationship"
+
+
+class TimeScopeKind(str, Enum):
+    UNSPECIFIED = "unspecified"
+    RANGE = "range"
+    POINT_IN_TIME = "point_in_time"
+    LATEST = "latest"
+
+
+class QueryTimeScope(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    kind: TimeScopeKind = TimeScopeKind.UNSPECIFIED
+    start_date: date | None = None
+    end_date: date | None = None
+    observation_date: date | None = None
+
+
+class QueryPlan(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    subjects: list[str] = Field(default_factory=list)
+    geographies: list[str] = Field(default_factory=list)
+    time_scope: QueryTimeScope = Field(default_factory=QueryTimeScope)
+    operators: list[QueryOperator] = Field(default_factory=list)
+    output_mode: QueryOutputMode = QueryOutputMode.TIME_SERIES
+
+
 class Geography(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -84,3 +123,105 @@ class QueryIntent(BaseModel):
     series_id: str | None = None
     series_ids: list[str | None] = Field(default_factory=list)
     parser_notes: list[str] = Field(default_factory=list)
+    query_plan: QueryPlan | None = None
+
+    @model_validator(mode="after")
+    def _initialize_query_plan(self) -> QueryIntent:
+        if self.query_plan is None:
+            self.query_plan = self._build_query_plan()
+        else:
+            self.task_type = self.planned_task_type
+        return self
+
+    @property
+    def planned_task_type(self) -> TaskType:
+        if self.query_plan is None:
+            return self.task_type
+        if self.query_plan.output_mode == QueryOutputMode.RELATIONSHIP:
+            return TaskType.RELATIONSHIP_ANALYSIS
+        if self.query_plan.output_mode == QueryOutputMode.CROSS_SECTION:
+            return TaskType.CROSS_SECTION
+        if QueryOperator.COMPARE in self.query_plan.operators:
+            return (
+                TaskType.STATE_GDP_COMPARISON
+                if self._is_state_gdp_comparison_plan(self.query_plan)
+                else TaskType.MULTI_SERIES_COMPARISON
+            )
+        return TaskType.SINGLE_SERIES_LOOKUP
+
+    def refresh_query_plan(self) -> QueryIntent:
+        self.query_plan = self._build_query_plan()
+        self.task_type = self.planned_task_type
+        return self
+
+    def _build_query_plan(self) -> QueryPlan:
+        return QueryPlan(
+            subjects=self._subjects_for_plan(),
+            geographies=[item.name for item in self.geographies if item.name],
+            time_scope=self._time_scope_for_plan(),
+            operators=self._operators_for_plan(),
+            output_mode=self._output_mode_for_plan(),
+        )
+
+    def _subjects_for_plan(self) -> list[str]:
+        values: list[str] = []
+        for candidate in [
+            *self.indicators,
+            self.search_text,
+            self.series_id,
+            *self.search_texts,
+            *self.series_ids,
+        ]:
+            if not candidate:
+                continue
+            if candidate not in values:
+                values.append(candidate)
+        return values
+
+    def _time_scope_for_plan(self) -> QueryTimeScope:
+        if self.observation_date is not None:
+            return QueryTimeScope(
+                kind=TimeScopeKind.POINT_IN_TIME,
+                observation_date=self.observation_date,
+                start_date=self.start_date,
+                end_date=self.end_date,
+            )
+        if self.start_date is not None or self.end_date is not None:
+            return QueryTimeScope(
+                kind=TimeScopeKind.RANGE,
+                start_date=self.start_date,
+                end_date=self.end_date,
+            )
+        if self.task_type == TaskType.CROSS_SECTION and self.needs_latest_value:
+            return QueryTimeScope(kind=TimeScopeKind.LATEST)
+        return QueryTimeScope(kind=TimeScopeKind.UNSPECIFIED)
+
+    def _operators_for_plan(self) -> list[QueryOperator]:
+        if self.task_type == TaskType.RELATIONSHIP_ANALYSIS:
+            return [QueryOperator.ANALYZE_RELATIONSHIP]
+        if self.task_type in (TaskType.STATE_GDP_COMPARISON, TaskType.MULTI_SERIES_COMPARISON):
+            return [QueryOperator.COMPARE]
+        if self.task_type == TaskType.CROSS_SECTION:
+            if self.cross_section_scope in (
+                CrossSectionScope.STATES,
+                CrossSectionScope.PROVIDED_GEOGRAPHIES,
+            ) or self.rank_limit is not None:
+                return [QueryOperator.RANK]
+            return [QueryOperator.LOOKUP]
+        return [QueryOperator.LOOKUP]
+
+    def _output_mode_for_plan(self) -> QueryOutputMode:
+        if self.task_type == TaskType.RELATIONSHIP_ANALYSIS:
+            return QueryOutputMode.RELATIONSHIP
+        if self.task_type == TaskType.CROSS_SECTION:
+            return QueryOutputMode.CROSS_SECTION
+        return QueryOutputMode.TIME_SERIES
+
+    def _is_state_gdp_comparison_plan(self, query_plan: QueryPlan) -> bool:
+        if self.task_type == TaskType.STATE_GDP_COMPARISON:
+            return True
+        if len(self.geographies) != 2:
+            return False
+        if any(item.geography_type != GeographyType.STATE for item in self.geographies):
+            return False
+        return any("gdp" in subject.lower() for subject in query_plan.subjects)

--- a/src/fred_query/services/cross_section_intent_service.py
+++ b/src/fred_query/services/cross_section_intent_service.py
@@ -97,7 +97,7 @@ class CrossSectionIntentService:
         intent.cross_section_scope = cls.infer_scope(intent, query=query)
         if any(term in cls._query_text(intent, query) for term in cls._ASCENDING_TERMS):
             intent.sort_descending = False
-        return intent
+        return intent.refresh_query_plan()
 
     @classmethod
     def promote_task_type(cls, intent: QueryIntent, *, query: str | None = None) -> QueryIntent:
@@ -112,4 +112,4 @@ class CrossSectionIntentService:
         ):
             intent.task_type = TaskType.CROSS_SECTION
             intent.cross_section_scope = CrossSectionScope.STATES
-        return intent
+        return intent.refresh_query_plan()

--- a/src/fred_query/services/cross_section_service.py
+++ b/src/fred_query/services/cross_section_service.py
@@ -329,6 +329,7 @@ class CrossSectionService:
             y_axis_title=displayed_results[0].series.units,
         )
         answer_text = self.answer_service.write_cross_section(analysis, intent=response_intent)
+        response_intent.refresh_query_plan()
         return QueryResponse(
             intent=response_intent,
             analysis=analysis,

--- a/src/fred_query/services/follow_up_intent_merger.py
+++ b/src/fred_query/services/follow_up_intent_merger.py
@@ -378,7 +378,7 @@ class FollowUpIntentMerger:
     ) -> QueryIntent:
         previous = self._session_intent(session_context)
         if previous is None or not self._is_follow_up_query(query, current, session_context):
-            return current
+            return current.refresh_query_plan()
 
         previous_targets = self._resolved_session_targets(session_context)
         current_targets = self._extract_targets_from_intent(current)
@@ -429,4 +429,4 @@ class FollowUpIntentMerger:
             current,
             previous_query=session_context.last_query if session_context is not None else None,
         )
-        return merged
+        return merged.refresh_query_plan()

--- a/src/fred_query/services/openai_parser_service.py
+++ b/src/fred_query/services/openai_parser_service.py
@@ -163,4 +163,4 @@ class OpenAIIntentParser:
                     or "Which geographies do you want included in the cross-section?"
                 )
 
-        return intent
+        return intent.refresh_query_plan()

--- a/src/fred_query/services/query_router.py
+++ b/src/fred_query/services/query_router.py
@@ -50,7 +50,7 @@ class QueryRouter:
             intent.clarification_needed = False
             intent.clarification_question = None
             intent.clarification_target_index = None
-            return intent
+            return intent.refresh_query_plan()
 
         selected_series_id = next((value for value in normalized_ids if value), None)
         if selected_series_id:
@@ -62,7 +62,7 @@ class QueryRouter:
             intent.parser_notes.append(
                 f"User selected explicit series ID {selected_series_id} from clarification options."
             )
-        return intent
+        return intent.refresh_query_plan()
 
     def route(
         self,
@@ -71,6 +71,7 @@ class QueryRouter:
         selected_series_ids: list[str | None] | None = None,
     ) -> RoutedQueryResponse:
         intent = self.apply_selected_series(intent, selected_series_ids)
+        task_type = intent.planned_task_type
 
         if intent.clarification_needed:
             candidate_series = self.clarification_resolver.build_candidates(intent)
@@ -81,7 +82,7 @@ class QueryRouter:
                 candidate_series=candidate_series,
             )
 
-        if intent.task_type == TaskType.STATE_GDP_COMPARISON:
+        if task_type == TaskType.STATE_GDP_COMPARISON:
             if len(intent.geographies) != 2:
                 return RoutedQueryResponse(
                     status=RoutedQueryStatus.NEEDS_CLARIFICATION,
@@ -103,7 +104,7 @@ class QueryRouter:
                 query_response=query_response,
             )
 
-        if intent.task_type == TaskType.SINGLE_SERIES_LOOKUP:
+        if task_type == TaskType.SINGLE_SERIES_LOOKUP:
             query_response = self.single_series_service.lookup(intent)
             return RoutedQueryResponse(
                 status=RoutedQueryStatus.COMPLETED,
@@ -112,7 +113,7 @@ class QueryRouter:
                 query_response=query_response,
             )
 
-        if intent.task_type == TaskType.CROSS_SECTION:
+        if task_type == TaskType.CROSS_SECTION:
             query_response = self.cross_section_service.analyze(intent)
             return RoutedQueryResponse(
                 status=RoutedQueryStatus.COMPLETED,
@@ -121,7 +122,7 @@ class QueryRouter:
                 query_response=query_response,
             )
 
-        if intent.task_type in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS):
+        if task_type in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS):
             query_response = self.relationship_service.analyze(intent)
             return RoutedQueryResponse(
                 status=RoutedQueryStatus.COMPLETED,

--- a/src/fred_query/services/relationship_service.py
+++ b/src/fred_query/services/relationship_service.py
@@ -369,4 +369,5 @@ class RelationshipAnalysisService:
             end_date=aligned_first[-1].date,
         )
         answer_text = self.answer_service.write_relationship_analysis(analysis)
+        response_intent.refresh_query_plan()
         return QueryResponse(intent=response_intent, analysis=analysis, chart=chart, answer_text=answer_text)

--- a/tests/test_openai_parser_service.py
+++ b/tests/test_openai_parser_service.py
@@ -9,8 +9,11 @@ from fred_query.schemas.intent import (
     CrossSectionScope,
     Geography,
     GeographyType,
+    QueryOperator,
+    QueryOutputMode,
     QueryIntent,
     TaskType,
+    TimeScopeKind,
     TransformType,
 )
 from fred_query.services.openai_parser_service import OpenAIIntentParser
@@ -35,6 +38,7 @@ class OpenAIIntentParserTest(unittest.TestCase):
     def test_parser_returns_intent_and_sets_original_query(self) -> None:
         intent = QueryIntent(
             task_type=TaskType.STATE_GDP_COMPARISON,
+            indicators=["real_gdp"],
             geographies=[
                 Geography(name="California", geography_type=GeographyType.STATE),
                 Geography(name="Texas", geography_type=GeographyType.STATE),
@@ -53,6 +57,12 @@ class OpenAIIntentParserTest(unittest.TestCase):
 
         self.assertEqual(parsed.task_type, TaskType.STATE_GDP_COMPARISON)
         self.assertEqual(parsed.original_query, "Compare California and Texas GDP since 2019")
+        assert parsed.query_plan is not None
+        self.assertEqual(parsed.query_plan.subjects, ["real_gdp"])
+        self.assertEqual(parsed.query_plan.geographies, ["California", "Texas"])
+        self.assertEqual(parsed.query_plan.time_scope.kind, TimeScopeKind.RANGE)
+        self.assertEqual(parsed.query_plan.operators, [QueryOperator.COMPARE])
+        self.assertEqual(parsed.query_plan.output_mode, QueryOutputMode.TIME_SERIES)
 
     def test_parser_requests_clarification_for_incomplete_state_gdp_intent(self) -> None:
         intent = QueryIntent(

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -5,7 +5,15 @@ import unittest
 
 from fred_query.schemas.analysis import AnalysisResult, QueryResponse, RoutedQueryStatus
 from fred_query.schemas.chart import AxisSpec, ChartSpec
-from fred_query.schemas.intent import ComparisonMode, QueryIntent, TaskType
+from fred_query.schemas.intent import (
+    ComparisonMode,
+    QueryIntent,
+    QueryOperator,
+    QueryOutputMode,
+    QueryPlan,
+    QueryTimeScope,
+    TaskType,
+)
 from fred_query.services.clarification_resolver import ClarificationResolver
 from fred_query.services.query_router import QueryRouter
 
@@ -79,6 +87,34 @@ class QueryRouterTest(unittest.TestCase):
         assert relationship_service.last_intent is not None
         self.assertEqual(relationship_service.last_intent.series_ids, ["UNRATE", "CPIAUCSL"])
         self.assertFalse(relationship_service.last_intent.clarification_needed)
+
+    def test_route_uses_query_plan_above_legacy_task_type(self) -> None:
+        relationship_service = _CapturingRelationshipService()
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=relationship_service,
+        )
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            query_plan=QueryPlan(
+                subjects=["unemployment rate", "inflation"],
+                geographies=[],
+                time_scope=QueryTimeScope(),
+                operators=[QueryOperator.ANALYZE_RELATIONSHIP],
+                output_mode=QueryOutputMode.RELATIONSHIP,
+            ),
+            search_texts=["unemployment rate", "inflation"],
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        assert relationship_service.last_intent is not None
+        self.assertEqual(relationship_service.last_intent.task_type, TaskType.RELATIONSHIP_ANALYSIS)
 
 
 if __name__ == "__main__":

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -7,6 +7,8 @@ from fred_query.schemas.analysis import AnalysisResult, QueryResponse, RoutedQue
 from fred_query.schemas.chart import AxisSpec, ChartSpec
 from fred_query.schemas.intent import (
     ComparisonMode,
+    Geography,
+    GeographyType,
     QueryIntent,
     QueryOperator,
     QueryOutputMode,
@@ -115,6 +117,32 @@ class QueryRouterTest(unittest.TestCase):
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
         assert relationship_service.last_intent is not None
         self.assertEqual(relationship_service.last_intent.task_type, TaskType.RELATIONSHIP_ANALYSIS)
+
+    def test_mixed_state_comparison_does_not_reclassify_as_state_gdp(self) -> None:
+        relationship_service = _CapturingRelationshipService()
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=relationship_service,
+        )
+        intent = QueryIntent(
+            task_type=TaskType.MULTI_SERIES_COMPARISON,
+            comparison_mode=ComparisonMode.MULTI_SERIES,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="Texas", geography_type=GeographyType.STATE),
+            ],
+            indicators=["state gdp", "unemployment rate"],
+            search_texts=["state gdp california texas", "unemployment rate california texas"],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        assert relationship_service.last_intent is not None
+        self.assertEqual(relationship_service.last_intent.task_type, TaskType.MULTI_SERIES_COMPARISON)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a first-class `QueryPlan` layer to `QueryIntent` with structured `subjects`, `geographies`, `time_scope`, `operators`, and `output_mode`
- derive the legacy `task_type` from that plan so existing state GDP, single-series, cross-section, multi-series, and relationship flows continue to route through the current services
- keep the plan synchronized after parser normalization, follow-up merges, cross-section promotion, explicit series selection, and response-time intent updates
- expand test coverage for parser plan population and plan-driven routing behavior

## Why
This change implements the task requirement to introduce a planning layer above the current task enum. The goal is to preserve the existing execution paths while making the parsed query shape more explicit and reusable for future routing and orchestration work.

## Implementation Details
- `QueryIntent` now auto-builds and refreshes a `QueryPlan`, and exposes a plan-derived task classification so the plan is authoritative while the current enum-based service contracts remain intact.
- The router now dispatches from the plan-derived classification instead of relying only on the stored `task_type` field.
- Parser and follow-up intent mutation paths were updated to refresh the plan after any task-shaping changes, which avoids stale routing metadata.
- Cross-section and relationship services refresh the returned intent plan so downstream consumers receive the final resolved shape.
- Tests cover both plan field population and the requirement that routing still works cleanly when the plan and legacy enum differ.