### PR TITLE
Build resolver v2 candidate generation and reranking

### DIFF
--- a/src/fred_query/services/clarification_resolver.py
+++ b/src/fred_query/services/clarification_resolver.py
@@ -1,50 +1,25 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
-from functools import lru_cache
 import re
 
 from fred_query.schemas.intent import QueryIntent, TaskType
 from fred_query.schemas.resolved_series import ClarificationBadge, ClarificationOption, SeriesSearchMatch
 from fred_query.services.fred_client import FREDClient
-
-
-@dataclass(frozen=True)
-class _ClarificationQueryFeatures:
-    normalized_text: str
-    wants_real: bool
-    wants_nominal: bool
-    wants_growth_rate: bool
-    wants_per_capita: bool
-    wants_market_based: bool
-    wants_seasonally_adjusted: bool | None
-
-
-@dataclass(frozen=True)
-class _ClarificationCandidateFeatures:
-    normalized_text: str
-    has_real: bool
-    has_nominal: bool
-    has_growth_rate: bool
-    has_index_level: bool
-    has_per_capita: bool
-    has_market_based_signal: bool
-    has_instrument_terms: bool
-    has_core: bool
-    has_pce: bool
-    has_cpi: bool
-    has_trimmed_mean: bool
-    has_ppi: bool
-    has_deflator: bool
-
-
-@dataclass(frozen=True)
-class _ClarificationContext:
-    search_text: str | None
-    example_searches: tuple[str, ...]
-    search_variants: tuple[str, ...]
-    anchor_terms: tuple[str, ...]
-    query_features: _ClarificationQueryFeatures
+from fred_query.services.series_match_scorer import (
+    CandidateFeatures as _ClarificationCandidateFeatures,
+    MatchScoreContext as _ClarificationContext,
+    build_match_score_context,
+    candidate_is_seasonally_adjusted,
+    candidate_text,
+    extract_candidate_features,
+    extract_candidate_features_from_text,
+    extract_clarification_examples,
+    has_specialized_inflation_variant,
+    is_base_price_index,
+    is_plain_inflation_request,
+    normalized_text,
+    score_candidate,
+)
 
 
 class ClarificationResolver:
@@ -57,150 +32,12 @@ class ClarificationResolver:
         "SA": "Semiannual",
         "A": "Annual",
     }
-    _STOP_WORDS = {
-        "a",
-        "about",
-        "all",
-        "an",
-        "and",
-        "another",
-        "any",
-        "are",
-        "at",
-        "be",
-        "between",
-        "data",
-        "do",
-        "economy",
-        "economic",
-        "for",
-        "from",
-        "in",
-        "into",
-        "is",
-        "like",
-        "measure",
-        "me",
-        "of",
-        "on",
-        "or",
-        "question",
-        "relationship",
-        "series",
-        "show",
-        "since",
-        "than",
-        "that",
-        "the",
-        "this",
-        "to",
-        "use",
-        "used",
-        "want",
-        "what",
-        "which",
-        "would",
-        "you",
-    }
-    _INSTRUMENT_TERMS = {
-        "bond",
-        "bonds",
-        "coupon",
-        "investment",
-        "maturity",
-        "note",
-        "notes",
-        "security",
-        "securities",
-        "treasury",
-        "yield",
-    }
-    _GROWTH_RATE_TERMS = (
-        "% chg",
-        "annual rate",
-        "annualized",
-        "growth rate",
-        "percent change",
-        "rate of change",
-        "year over year",
-        "yr. ago",
-        "yoy",
-    )
-    _REAL_TERMS = (
-        "constant dollar",
-        "constant dollars",
-        "inflation-adjusted",
-    )
-    _NOMINAL_TERMS = (
-        "current dollar",
-        "current dollars",
-        "current-dollar",
-        "nominal",
-    )
-    _PER_CAPITA_TERMS = (
-        "per capita",
-        "per-capita",
-    )
-    _MARKET_BASED_TERMS = (
-        "breakeven",
-        "inflation compensation",
-        "inflation-indexed",
-        "market-based",
-    )
-
     def __init__(self, fred_client: FREDClient) -> None:
         self.fred_client = fred_client
 
     @classmethod
-    def _tokenize(cls, text: str | None) -> list[str]:
-        if not text:
-            return []
-        return re.findall(r"[A-Za-z0-9]+", text.lower())
-
-    @classmethod
-    def _significant_terms(cls, texts: list[str]) -> list[str]:
-        seen: set[str] = set()
-        terms: list[str] = []
-        for text in texts:
-            for token in cls._tokenize(text):
-                if len(token) < 3 or token in cls._STOP_WORDS:
-                    continue
-                if token in seen:
-                    continue
-                seen.add(token)
-                terms.append(token)
-        return terms
-
-    @classmethod
     def _extract_clarification_examples(cls, question: str | None) -> list[str]:
-        if not question:
-            return []
-
-        source = question.strip()
-        if ":" in source:
-            source = source.split(":", maxsplit=1)[1]
-        else:
-            match = re.search(r"\bmean\b(?P<tail>.+)$", source, flags=re.IGNORECASE)
-            if match:
-                source = match.group("tail")
-
-        source = re.sub(r"\bor\s+another\b.*$", "", source, flags=re.IGNORECASE).strip(" ?.")
-        source = re.sub(r"\bor\s+", ", ", source, flags=re.IGNORECASE)
-
-        examples: list[str] = []
-        seen: set[str] = set()
-        for part in source.split(","):
-            cleaned = re.sub(r"^(and|or)\s+", "", part.strip(), flags=re.IGNORECASE).strip(" ?.")
-            if not cleaned:
-                continue
-            lowered = cleaned.lower()
-            if lowered.startswith("another") or lowered.startswith("other"):
-                continue
-            if lowered in seen:
-                continue
-            seen.add(lowered)
-            examples.append(cleaned)
-        return examples[:3]
+        return extract_clarification_examples(question)
 
     @staticmethod
     def clarification_search_text(intent: QueryIntent) -> str | None:
@@ -215,216 +52,19 @@ class ClarificationResolver:
 
     @classmethod
     def _build_context(cls, intent: QueryIntent) -> _ClarificationContext | None:
-        search_text = cls.clarification_search_text(intent)
-        if not search_text:
-            return None
-
-        example_searches = cls._extract_clarification_examples(intent.clarification_question)
-        search_variants: list[str] = []
-        for value in [*example_searches, search_text]:
-            normalized = value.strip()
-            if normalized and normalized not in search_variants:
-                search_variants.append(normalized)
-
-        context_texts = cls._context_texts_for_intent(
-            intent,
-            search_text=search_text,
-            example_searches=example_searches,
-        )
-        anchor_terms = cls._significant_terms(
-            context_texts
-        )
-        query_text = " ".join(
-            part
-            for part in context_texts
-            if part
-        )
-        return _ClarificationContext(
-            search_text=search_text,
-            example_searches=tuple(example_searches),
-            search_variants=tuple(search_variants),
-            anchor_terms=tuple(anchor_terms),
-            query_features=cls._extract_query_features(query_text),
-        )
-
-    @classmethod
-    def _text_has_any(cls, text: str, terms: tuple[str, ...]) -> bool:
-        return any(term in text for term in terms)
-
-    @classmethod
-    def _context_texts_for_intent(
-        cls,
-        intent: QueryIntent,
-        *,
-        search_text: str,
-        example_searches: list[str],
-    ) -> list[str]:
-        texts = [
-            intent.clarification_question or "",
-            search_text,
-            *example_searches,
-        ]
-        if intent.task_type not in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS):
-            texts.insert(0, intent.original_query or "")
-        return texts
-
-    @classmethod
-    def _extract_query_features(cls, text: str) -> _ClarificationQueryFeatures:
-        normalized = cls._normalized_text(text)
-        wants_seasonally_adjusted: bool | None = None
-        if "not seasonally adjusted" in normalized:
-            wants_seasonally_adjusted = False
-        elif "seasonally adjusted" in normalized:
-            wants_seasonally_adjusted = True
-
-        return _ClarificationQueryFeatures(
-            normalized_text=normalized,
-            wants_real=cls._has_real_signal(normalized),
-            wants_nominal=cls._has_nominal_signal(normalized),
-            wants_growth_rate=cls._text_has_any(normalized, cls._GROWTH_RATE_TERMS),
-            wants_per_capita=cls._text_has_any(normalized, cls._PER_CAPITA_TERMS),
-            wants_market_based=cls._text_has_any(normalized, cls._MARKET_BASED_TERMS)
-            or any(term in normalized for term in cls._INSTRUMENT_TERMS),
-            wants_seasonally_adjusted=wants_seasonally_adjusted,
-        )
+        return build_match_score_context(intent)
 
     @staticmethod
-    @lru_cache(maxsize=1024)
     def _extract_candidate_features_from_text(text: str) -> _ClarificationCandidateFeatures:
-        has_growth_rate = ClarificationResolver._text_has_any(text, ClarificationResolver._GROWTH_RATE_TERMS)
-        has_real = ClarificationResolver._has_real_signal(text)
-        return _ClarificationCandidateFeatures(
-            normalized_text=text,
-            has_real=has_real,
-            has_nominal=ClarificationResolver._has_nominal_signal(text, has_real=has_real),
-            has_growth_rate=has_growth_rate,
-            has_index_level="index" in text and not has_growth_rate,
-            has_per_capita=ClarificationResolver._text_has_any(text, ClarificationResolver._PER_CAPITA_TERMS),
-            has_market_based_signal=ClarificationResolver._text_has_any(text, ClarificationResolver._MARKET_BASED_TERMS),
-            has_instrument_terms=any(term in text for term in ClarificationResolver._INSTRUMENT_TERMS),
-            has_core=(
-                "core" in text
-                or "less food and energy" in text
-                or "excluding food and energy" in text
-            ),
-            has_pce=(
-                "personal consumption expenditures" in text
-                or re.search(r"\bpce\b", text) is not None
-            ),
-            has_cpi="consumer price index" in text or re.search(r"\bcpi\b", text) is not None,
-            has_trimmed_mean="trimmed mean" in text,
-            has_ppi="producer price" in text or re.search(r"\bppi\b", text) is not None,
-            has_deflator="deflator" in text,
-        )
+        return extract_candidate_features_from_text(text)
 
     @classmethod
     def _extract_candidate_features(cls, candidate: SeriesSearchMatch) -> _ClarificationCandidateFeatures:
-        text = cls._candidate_text(candidate)
-        return cls._extract_candidate_features_from_text(text)
-
-    @classmethod
-    def _has_real_signal(cls, text: str) -> bool:
-        if cls._text_has_any(text, cls._REAL_TERMS):
-            return True
-        if re.search(r"\breal\b", text) is not None:
-            return True
-        return re.search(r"\bchained\b.+\bdollar", text) is not None
-
-    @classmethod
-    def _has_nominal_signal(cls, text: str, *, has_real: bool | None = None) -> bool:
-        if cls._text_has_any(text, cls._NOMINAL_TERMS):
-            return True
-        if has_real is None:
-            has_real = cls._has_real_signal(text)
-        if has_real:
-            return False
-        return re.search(r"\bdollars?\b", text) is not None
+        return extract_candidate_features(candidate)
 
     @staticmethod
     def _candidate_is_seasonally_adjusted(candidate: SeriesSearchMatch) -> bool | None:
-        adjustment = (candidate.seasonal_adjustment or "").strip().lower()
-        if not adjustment:
-            return None
-        if "not seasonally adjusted" in adjustment or adjustment == "nsa":
-            return False
-        if "seasonally adjusted" in adjustment or adjustment in {"sa", "saar"}:
-            return True
-        return None
-
-    @classmethod
-    def _generic_score_adjustment(
-        cls,
-        candidate: SeriesSearchMatch,
-        candidate_features: _ClarificationCandidateFeatures,
-        *,
-        context: _ClarificationContext,
-    ) -> float:
-        score = 0.0
-        query_features = context.query_features
-
-        if query_features.wants_real:
-            if candidate_features.has_real:
-                score += 2.0
-            elif candidate_features.has_nominal:
-                score -= 1.5
-
-        if query_features.wants_nominal:
-            if candidate_features.has_nominal:
-                score += 2.0
-            elif candidate_features.has_real:
-                score -= 1.5
-
-        if query_features.wants_growth_rate:
-            if candidate_features.has_growth_rate:
-                score += 1.5
-            elif candidate_features.has_index_level:
-                score -= 0.5
-
-        if query_features.wants_per_capita:
-            if candidate_features.has_per_capita:
-                score += 1.5
-            else:
-                score -= 0.5
-
-        if query_features.wants_market_based:
-            if candidate_features.has_market_based_signal or candidate_features.has_instrument_terms:
-                score += 1.5
-        elif candidate_features.has_instrument_terms:
-            score -= 1.5
-
-        seasonally_adjusted = cls._candidate_is_seasonally_adjusted(candidate)
-        if query_features.wants_seasonally_adjusted is True:
-            if seasonally_adjusted is True:
-                score += 1.0
-            elif seasonally_adjusted is False:
-                score -= 0.5
-        elif query_features.wants_seasonally_adjusted is False:
-            if seasonally_adjusted is False:
-                score += 1.0
-            elif seasonally_adjusted is True:
-                score -= 0.5
-
-        return score
-
-    @classmethod
-    def _inflation_profile_score_adjustment(
-        cls,
-        candidate: SeriesSearchMatch,
-        *,
-        context: _ClarificationContext,
-        candidate_features: _ClarificationCandidateFeatures,
-    ) -> float:
-        if not cls._is_plain_inflation_request(list(context.search_variants)):
-            return 0.0
-
-        score = 0.0
-        if cls._is_base_price_index(candidate):
-            score += 2.5
-        if cls._has_specialized_inflation_variant(candidate):
-            score -= 2.0
-        if candidate_features.has_instrument_terms and not context.query_features.wants_market_based:
-            score -= 0.5
-        return score
+        return candidate_is_seasonally_adjusted(candidate)
 
     @classmethod
     def _score_candidate(
@@ -433,54 +73,7 @@ class ClarificationResolver:
         *,
         context: _ClarificationContext,
     ) -> float:
-        title_text = f"{candidate.series_id} {candidate.title}".lower()
-        full_text = " ".join(
-            [
-                candidate.series_id,
-                candidate.title,
-                candidate.notes or "",
-                candidate.units or "",
-                candidate.frequency or "",
-            ]
-        ).lower()
-
-        candidate_features = cls._extract_candidate_features(candidate)
-        score = 0.0
-        title_matches = 0
-        for term in context.anchor_terms:
-            if term in title_text:
-                score += 3.0
-                title_matches += 1
-            elif term in full_text:
-                score += 1.0
-
-        for phrase in context.search_variants:
-            lowered_phrase = phrase.lower().strip()
-            if not lowered_phrase:
-                continue
-            if lowered_phrase in full_text:
-                score += 5.0
-                continue
-
-            phrase_terms = cls._significant_terms([phrase])
-            if phrase_terms:
-                matched_terms = sum(1 for term in phrase_terms if term in title_text)
-                if matched_terms >= max(1, min(2, len(phrase_terms))):
-                    score += 3.5
-
-        if candidate.popularity is not None:
-            score += min(candidate.popularity / 25.0, 2.0)
-
-        if title_matches == 0:
-            score -= 2.0
-
-        score += cls._generic_score_adjustment(candidate, candidate_features, context=context)
-        score += cls._inflation_profile_score_adjustment(
-            candidate,
-            context=context,
-            candidate_features=candidate_features,
-        )
-        return score
+        return score_candidate(candidate, context=context)
 
     @classmethod
     def _candidate_title_key(cls, candidate: SeriesSearchMatch) -> str:
@@ -539,25 +132,11 @@ class ClarificationResolver:
 
     @staticmethod
     def _normalized_text(value: str | None) -> str:
-        return (value or "").strip().lower()
+        return normalized_text(value)
 
     @classmethod
     def _is_plain_inflation_request(cls, search_variants: list[str]) -> bool:
-        combined = " ".join(search_variants).lower()
-        if "inflation" not in combined:
-            return False
-        return not any(
-            term in combined
-            for term in (
-                "core",
-                "trimmed",
-                "breakeven",
-                "deflator",
-                "producer",
-                "annualized",
-                "year over year",
-            )
-        )
+        return is_plain_inflation_request(search_variants)
 
     @classmethod
     def _candidate_has_any(cls, candidate: SeriesSearchMatch, terms: tuple[str, ...]) -> bool:
@@ -566,35 +145,11 @@ class ClarificationResolver:
 
     @classmethod
     def _is_base_price_index(cls, candidate: SeriesSearchMatch) -> bool:
-        text = cls._candidate_text(candidate)
-        if not (
-            "consumer price index" in text
-            or "personal consumption expenditures" in text
-            or re.search(r"\bcpi\b", text)
-            or re.search(r"\bpce\b", text)
-        ):
-            return False
-        return "index" in text and not cls._has_specialized_inflation_variant(candidate)
+        return is_base_price_index(candidate)
 
     @classmethod
     def _has_specialized_inflation_variant(cls, candidate: SeriesSearchMatch) -> bool:
-        return cls._candidate_has_any(
-            candidate,
-            (
-                "trimmed mean",
-                "core",
-                "excluding food and energy",
-                "less food and energy",
-                "annual rate",
-                "annualized",
-                "% chg",
-                "percent change",
-                "breakeven",
-                "inflation-indexed",
-                "producer price",
-                "deflator",
-            ),
-        )
+        return has_specialized_inflation_variant(candidate)
 
     def build_candidates(self, intent: QueryIntent) -> list[SeriesSearchMatch]:
         context = self._build_context(intent)
@@ -671,18 +226,7 @@ class ClarificationResolver:
 
     @staticmethod
     def _candidate_text(candidate: SeriesSearchMatch) -> str:
-        return " ".join(
-            value
-            for value in [
-                candidate.series_id,
-                candidate.title,
-                candidate.units or "",
-                candidate.frequency or "",
-                candidate.seasonal_adjustment or "",
-                candidate.notes or "",
-            ]
-            if value
-        ).lower()
+        return candidate_text(candidate)
 
     @classmethod
     def _inflation_selection_hint_for_candidate(

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -87,6 +87,26 @@ class ResolverService:
     """Resolve deterministic series mappings for the first workflow."""
 
     _SEARCH_CANDIDATE_LIMIT = 15
+    _RANKING_WEIGHTS = {
+        "frequency_match": 1.75,
+        "frequency_mismatch": 0.75,
+        "geography_exact_match": 3.0,
+        "geography_partial_match": 1.5,
+        "geography_missing_penalty": 1.0,
+        "indicator_exact_phrase_match": 2.5,
+        "indicator_title_term_match": 2.0,
+        "indicator_full_text_term_match": 1.0,
+        "plain_inflation_base_index_bonus": 3.0,
+        "plain_inflation_specialized_penalty": 2.0,
+        "plain_inflation_cpi_bonus": 1.0,
+        "plain_inflation_pce_bonus": 0.5,
+        "plain_inflation_breakeven_penalty": 2.0,
+        "search_rank_base_bonus": 2.0,
+        "search_rank_decay": 0.15,
+        "resolved_score_floor": 0.55,
+        "resolved_score_scale": 20.0,
+        "resolved_score_cap": 0.99,
+    }
     _STOP_WORDS = {
         "a",
         "an",
@@ -185,9 +205,9 @@ class ResolverService:
             if term not in query_text:
                 continue
             if any(alias in normalized_frequency for alias in aliases):
-                score += 1.75
+                score += cls._RANKING_WEIGHTS["frequency_match"]
             else:
-                score -= 0.75
+                score -= cls._RANKING_WEIGHTS["frequency_mismatch"]
         return score
 
     @classmethod
@@ -211,11 +231,11 @@ class ResolverService:
 
         matched_terms = sum(1 for term in geography_terms if term in candidate_text)
         if matched_terms == len(geography_terms):
-            return 3.0
+            return cls._RANKING_WEIGHTS["geography_exact_match"]
         if matched_terms > 0:
-            return 1.5
+            return cls._RANKING_WEIGHTS["geography_partial_match"]
         if any(term in query_text for term in geography_terms):
-            return -1.0
+            return -cls._RANKING_WEIGHTS["geography_missing_penalty"]
         return 0.0
 
     @classmethod
@@ -226,7 +246,7 @@ class ResolverService:
 
         candidate_text = cls._candidate_text(candidate)
         if phrase in candidate_text:
-            return 2.5
+            return cls._RANKING_WEIGHTS["indicator_exact_phrase_match"]
 
         terms = cls._significant_terms(indicator)
         if not terms:
@@ -236,9 +256,9 @@ class ResolverService:
         title_matches = sum(1 for term in terms if term in title_text)
         full_matches = sum(1 for term in terms if term in candidate_text)
         if title_matches >= max(1, min(2, len(terms))):
-            return 2.0
+            return cls._RANKING_WEIGHTS["indicator_title_term_match"]
         if full_matches >= max(1, min(2, len(terms))):
-            return 1.0
+            return cls._RANKING_WEIGHTS["indicator_full_text_term_match"]
         return 0.0
 
     @classmethod
@@ -253,17 +273,17 @@ class ResolverService:
         if is_plain_inflation_request(search_variants):
             score = 0.0
             if is_base_price_index(candidate):
-                score += 3.0
+                score += cls._RANKING_WEIGHTS["plain_inflation_base_index_bonus"]
             if has_specialized_inflation_variant(candidate):
-                score -= 2.0
+                score -= cls._RANKING_WEIGHTS["plain_inflation_specialized_penalty"]
             candidate_features = extract_candidate_features(candidate)
             if candidate_features.has_cpi:
-                score += 1.0
+                score += cls._RANKING_WEIGHTS["plain_inflation_cpi_bonus"]
             elif candidate_features.has_pce:
-                score += 0.5
+                score += cls._RANKING_WEIGHTS["plain_inflation_pce_bonus"]
             candidate_text = cls._candidate_text(candidate)
             if "breakeven" in candidate_text:
-                score -= 2.0
+                score -= cls._RANKING_WEIGHTS["plain_inflation_breakeven_penalty"]
             return score
         return 0.0
 
@@ -306,7 +326,11 @@ class ResolverService:
 
         ranked: list[tuple[float, SeriesSearchMatch]] = []
         for rank, candidate in enumerate(matches):
-            score = max(0.0, 2.0 - (rank * 0.15))
+            score = max(
+                0.0,
+                self._RANKING_WEIGHTS["search_rank_base_bonus"]
+                - (rank * self._RANKING_WEIGHTS["search_rank_decay"]),
+            )
             if context is not None:
                 score += score_candidate(candidate, context=context)
             score += self._frequency_score(candidate, query_text=query_text)
@@ -362,7 +386,14 @@ class ResolverService:
 
         winner_score, search_match = ranked_matches[0]
         metadata = self.fred_client.get_series_metadata(search_match.series_id)
-        normalized_score = min(0.99, max(0.55, 0.55 + (winner_score / 20.0)))
+        normalized_score = min(
+            self._RANKING_WEIGHTS["resolved_score_cap"],
+            max(
+                self._RANKING_WEIGHTS["resolved_score_floor"],
+                self._RANKING_WEIGHTS["resolved_score_floor"]
+                + (winner_score / self._RANKING_WEIGHTS["resolved_score_scale"]),
+            ),
+        )
         resolution_reason = (
             search_resolution_reason
             or "Resolved the query via reranked FRED search candidates. Best match from the top {candidate_count} hits was {series_id}."

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -6,8 +6,15 @@ import re
 from fred_query.schemas.intent import QueryIntent, TaskType
 from fred_query.schemas.analysis import ObservationPoint
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
-from fred_query.services.clarification_resolver import ClarificationResolver
 from fred_query.services.fred_client import FREDClient
+from fred_query.services.series_match_scorer import (
+    build_match_score_context,
+    extract_candidate_features,
+    is_base_price_index,
+    is_plain_inflation_request,
+    has_specialized_inflation_variant,
+    score_candidate,
+)
 
 
 STATE_NAME_TO_CODE = {
@@ -243,13 +250,13 @@ class ResolverService:
         indicator: str,
     ) -> float:
         search_variants = [value for value in [search_text, indicator] if value]
-        if ClarificationResolver._is_plain_inflation_request(search_variants):
+        if is_plain_inflation_request(search_variants):
             score = 0.0
-            if ClarificationResolver._is_base_price_index(candidate):
+            if is_base_price_index(candidate):
                 score += 3.0
-            if ClarificationResolver._has_specialized_inflation_variant(candidate):
+            if has_specialized_inflation_variant(candidate):
                 score -= 2.0
-            candidate_features = ClarificationResolver._extract_candidate_features(candidate)
+            candidate_features = extract_candidate_features(candidate)
             if candidate_features.has_cpi:
                 score += 1.0
             elif candidate_features.has_pce:
@@ -290,7 +297,7 @@ class ResolverService:
             geography=geography,
             indicator=indicator,
         )
-        context = ClarificationResolver._build_context(intent)
+        context = build_match_score_context(intent)
         query_text = " ".join(
             value.lower()
             for value in [search_text, geography, indicator]
@@ -301,7 +308,7 @@ class ResolverService:
         for rank, candidate in enumerate(matches):
             score = max(0.0, 2.0 - (rank * 0.15))
             if context is not None:
-                score += ClarificationResolver._score_candidate(candidate, context=context)
+                score += score_candidate(candidate, context=context)
             score += self._frequency_score(candidate, query_text=query_text)
             score += self._geography_score(candidate, geography=geography, query_text=query_text)
             score += self._indicator_phrase_score(candidate, indicator=indicator)

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from datetime import date
 import re
 
-from fred_query.schemas.intent import QueryIntent, TaskType
 from fred_query.schemas.analysis import ObservationPoint
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
 from fred_query.services.fred_client import FREDClient
 from fred_query.services.series_match_scorer import (
-    build_match_score_context,
+    build_match_score_context_from_parts,
     extract_candidate_features,
     is_base_price_index,
     is_plain_inflation_request,
@@ -290,20 +289,6 @@ class ResolverService:
             return score
         return 0.0
 
-    @classmethod
-    def _build_search_intent(cls, *, search_text: str, geography: str, indicator: str) -> QueryIntent:
-        original_query = " ".join(
-            value
-            for value in [indicator, geography, search_text]
-            if value and value != "unknown_indicator" and value != "Unspecified"
-        )
-        return QueryIntent(
-            task_type=TaskType.SINGLE_SERIES_LOOKUP,
-            original_query=original_query or search_text,
-            search_text=search_text,
-            indicators=[indicator] if indicator and indicator != "unknown_indicator" else [],
-        )
-
     def _rank_search_matches(
         self,
         *,
@@ -315,12 +300,15 @@ class ResolverService:
         if not matches:
             return []
 
-        intent = self._build_search_intent(
-            search_text=search_text,
-            geography=geography,
-            indicator=indicator,
+        original_query = " ".join(
+            value
+            for value in [indicator, geography, search_text]
+            if value and value != "unknown_indicator" and value != "Unspecified"
         )
-        context = build_match_score_context(intent)
+        context = build_match_score_context_from_parts(
+            search_text=search_text,
+            original_query=original_query or search_text,
+        )
         query_text = " ".join(
             value.lower()
             for value in [search_text, geography, indicator]

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from datetime import date
+import re
 
+from fred_query.schemas.intent import QueryIntent, TaskType
 from fred_query.schemas.analysis import ObservationPoint
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
+from fred_query.services.clarification_resolver import ClarificationResolver
 from fred_query.services.fred_client import FREDClient
 
 
@@ -76,6 +79,28 @@ STATE_SERIES_PATTERNS = {
 class ResolverService:
     """Resolve deterministic series mappings for the first workflow."""
 
+    _SEARCH_CANDIDATE_LIMIT = 15
+    _STOP_WORDS = {
+        "a",
+        "an",
+        "and",
+        "for",
+        "in",
+        "of",
+        "the",
+        "to",
+        "united",
+        "states",
+    }
+    _FREQUENCY_TERMS = {
+        "daily": ("d", "daily"),
+        "weekly": ("w", "weekly"),
+        "monthly": ("m", "monthly"),
+        "quarterly": ("q", "quarterly"),
+        "annual": ("a", "annual"),
+        "yearly": ("a", "annual"),
+    }
+
     def __init__(self, fred_client: FREDClient) -> None:
         self.fred_client = fred_client
 
@@ -113,6 +138,186 @@ class ResolverService:
             source_url=metadata.source_url,
         )
 
+    @classmethod
+    def _tokenize(cls, value: str | None) -> list[str]:
+        if not value:
+            return []
+        return re.findall(r"[A-Za-z0-9]+", value.lower())
+
+    @classmethod
+    def _significant_terms(cls, value: str | None) -> list[str]:
+        return [
+            token
+            for token in cls._tokenize(value)
+            if len(token) >= 3 and token not in cls._STOP_WORDS
+        ]
+
+    @classmethod
+    def _candidate_text(cls, candidate: SeriesSearchMatch) -> str:
+        return " ".join(
+            part
+            for part in [
+                candidate.series_id,
+                candidate.title,
+                candidate.units or "",
+                candidate.frequency or "",
+                candidate.seasonal_adjustment or "",
+                candidate.notes or "",
+            ]
+            if part
+        ).lower()
+
+    @classmethod
+    def _frequency_score(cls, candidate: SeriesSearchMatch, *, query_text: str) -> float:
+        normalized_frequency = (candidate.frequency or "").strip().lower()
+        if not normalized_frequency:
+            return 0.0
+
+        score = 0.0
+        for term, aliases in cls._FREQUENCY_TERMS.items():
+            if term not in query_text:
+                continue
+            if any(alias in normalized_frequency for alias in aliases):
+                score += 1.75
+            else:
+                score -= 0.75
+        return score
+
+    @classmethod
+    def _geography_score(
+        cls,
+        candidate: SeriesSearchMatch,
+        *,
+        geography: str,
+        query_text: str,
+    ) -> float:
+        normalized_geography = geography.strip().lower()
+        if not normalized_geography or normalized_geography == "unspecified":
+            return 0.0
+        if normalized_geography in {"united states", "u.s.", "us", "national"}:
+            return 0.0
+
+        candidate_text = cls._candidate_text(candidate)
+        geography_terms = cls._significant_terms(geography)
+        if not geography_terms:
+            return 0.0
+
+        matched_terms = sum(1 for term in geography_terms if term in candidate_text)
+        if matched_terms == len(geography_terms):
+            return 3.0
+        if matched_terms > 0:
+            return 1.5
+        if any(term in query_text for term in geography_terms):
+            return -1.0
+        return 0.0
+
+    @classmethod
+    def _indicator_phrase_score(cls, candidate: SeriesSearchMatch, *, indicator: str) -> float:
+        phrase = indicator.strip().lower()
+        if not phrase or phrase == "unknown_indicator":
+            return 0.0
+
+        candidate_text = cls._candidate_text(candidate)
+        if phrase in candidate_text:
+            return 2.5
+
+        terms = cls._significant_terms(indicator)
+        if not terms:
+            return 0.0
+
+        title_text = f"{candidate.series_id} {candidate.title}".lower()
+        title_matches = sum(1 for term in terms if term in title_text)
+        full_matches = sum(1 for term in terms if term in candidate_text)
+        if title_matches >= max(1, min(2, len(terms))):
+            return 2.0
+        if full_matches >= max(1, min(2, len(terms))):
+            return 1.0
+        return 0.0
+
+    @classmethod
+    def _semantic_profile_score(
+        cls,
+        candidate: SeriesSearchMatch,
+        *,
+        search_text: str,
+        indicator: str,
+    ) -> float:
+        search_variants = [value for value in [search_text, indicator] if value]
+        if ClarificationResolver._is_plain_inflation_request(search_variants):
+            score = 0.0
+            if ClarificationResolver._is_base_price_index(candidate):
+                score += 3.0
+            if ClarificationResolver._has_specialized_inflation_variant(candidate):
+                score -= 2.0
+            candidate_features = ClarificationResolver._extract_candidate_features(candidate)
+            if candidate_features.has_cpi:
+                score += 1.0
+            elif candidate_features.has_pce:
+                score += 0.5
+            candidate_text = cls._candidate_text(candidate)
+            if "breakeven" in candidate_text:
+                score -= 2.0
+            return score
+        return 0.0
+
+    @classmethod
+    def _build_search_intent(cls, *, search_text: str, geography: str, indicator: str) -> QueryIntent:
+        original_query = " ".join(
+            value
+            for value in [indicator, geography, search_text]
+            if value and value != "unknown_indicator" and value != "Unspecified"
+        )
+        return QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            original_query=original_query or search_text,
+            search_text=search_text,
+            indicators=[indicator] if indicator and indicator != "unknown_indicator" else [],
+        )
+
+    def _rank_search_matches(
+        self,
+        *,
+        search_text: str,
+        geography: str,
+        indicator: str,
+    ) -> list[tuple[float, SeriesSearchMatch]]:
+        matches = self.fred_client.search_series(search_text, limit=self._SEARCH_CANDIDATE_LIMIT)
+        if not matches:
+            return []
+
+        intent = self._build_search_intent(
+            search_text=search_text,
+            geography=geography,
+            indicator=indicator,
+        )
+        context = ClarificationResolver._build_context(intent)
+        query_text = " ".join(
+            value.lower()
+            for value in [search_text, geography, indicator]
+            if value and value not in {"unknown_indicator", "Unspecified"}
+        )
+
+        ranked: list[tuple[float, SeriesSearchMatch]] = []
+        for rank, candidate in enumerate(matches):
+            score = max(0.0, 2.0 - (rank * 0.15))
+            if context is not None:
+                score += ClarificationResolver._score_candidate(candidate, context=context)
+            score += self._frequency_score(candidate, query_text=query_text)
+            score += self._geography_score(candidate, geography=geography, query_text=query_text)
+            score += self._indicator_phrase_score(candidate, indicator=indicator)
+            score += self._semantic_profile_score(candidate, search_text=search_text, indicator=indicator)
+            ranked.append((score, candidate))
+
+        ranked.sort(
+            key=lambda item: (
+                item[0],
+                item[1].popularity or 0,
+                item[1].title,
+            ),
+            reverse=True,
+        )
+        return ranked
+
     def resolve_series(
         self,
         *,
@@ -140,27 +345,34 @@ class ResolverService:
         if not search_text:
             raise ValueError(no_target_message or "I need a resolvable series target before I can continue.")
 
-        matches = self.fred_client.search_series(search_text, limit=5)
-        if not matches:
+        ranked_matches = self._rank_search_matches(
+            search_text=search_text,
+            geography=geography,
+            indicator=indicator,
+        )
+        if not ranked_matches:
             raise ValueError(f"No FRED series matched search text '{search_text}'.")
 
-        search_match = matches[0]
+        winner_score, search_match = ranked_matches[0]
         metadata = self.fred_client.get_series_metadata(search_match.series_id)
+        normalized_score = min(0.99, max(0.55, 0.55 + (winner_score / 20.0)))
         resolution_reason = (
-            search_resolution_reason or "Resolved the query via FRED search. Top match was {series_id}."
+            search_resolution_reason
+            or "Resolved the query via reranked FRED search candidates. Best match from the top {candidate_count} hits was {series_id}."
         ).format(
             geography=geography,
             indicator=indicator,
             search_text=search_text,
             series_id=metadata.series_id,
             title=metadata.title,
+            candidate_count=len(ranked_matches),
         )
         return (
             self.build_resolved_series(
                 metadata,
                 geography=geography,
                 indicator=indicator,
-                score=0.8,
+                score=normalized_score,
                 resolution_reason=resolution_reason,
             ),
             metadata,

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -103,9 +103,12 @@ class ResolverService:
         "plain_inflation_breakeven_penalty": 2.0,
         "search_rank_base_bonus": 2.0,
         "search_rank_decay": 0.15,
-        "resolved_score_floor": 0.55,
-        "resolved_score_scale": 20.0,
-        "resolved_score_cap": 0.99,
+        "confidence_single_candidate": 0.72,
+        "confidence_close_call": 0.6,
+        "confidence_moderate_gap": 0.78,
+        "confidence_clear_gap": 0.92,
+        "confidence_moderate_gap_threshold": 2.0,
+        "confidence_clear_gap_threshold": 5.0,
     }
     _STOP_WORDS = {
         "a",
@@ -349,6 +352,21 @@ class ResolverService:
         )
         return ranked
 
+    @classmethod
+    def _confidence_from_rank_gap(cls, ranked_matches: list[tuple[float, SeriesSearchMatch]]) -> float:
+        if len(ranked_matches) == 1:
+            return cls._RANKING_WEIGHTS["confidence_single_candidate"]
+
+        winner_score = ranked_matches[0][0]
+        runner_up_score = ranked_matches[1][0]
+        margin = winner_score - runner_up_score
+
+        if margin >= cls._RANKING_WEIGHTS["confidence_clear_gap_threshold"]:
+            return cls._RANKING_WEIGHTS["confidence_clear_gap"]
+        if margin >= cls._RANKING_WEIGHTS["confidence_moderate_gap_threshold"]:
+            return cls._RANKING_WEIGHTS["confidence_moderate_gap"]
+        return cls._RANKING_WEIGHTS["confidence_close_call"]
+
     def resolve_series(
         self,
         *,
@@ -386,14 +404,7 @@ class ResolverService:
 
         winner_score, search_match = ranked_matches[0]
         metadata = self.fred_client.get_series_metadata(search_match.series_id)
-        normalized_score = min(
-            self._RANKING_WEIGHTS["resolved_score_cap"],
-            max(
-                self._RANKING_WEIGHTS["resolved_score_floor"],
-                self._RANKING_WEIGHTS["resolved_score_floor"]
-                + (winner_score / self._RANKING_WEIGHTS["resolved_score_scale"]),
-            ),
-        )
+        normalized_score = self._confidence_from_rank_gap(ranked_matches)
         resolution_reason = (
             search_resolution_reason
             or "Resolved the query via reranked FRED search candidates. Best match from the top {candidate_count} hits was {series_id}."

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from datetime import date
 import re
+from typing import Callable
 
 from fred_query.schemas.analysis import ObservationPoint
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
 from fred_query.services.fred_client import FREDClient
 from fred_query.services.series_match_scorer import (
     build_match_score_context_from_parts,
+    candidate_text,
     extract_candidate_features,
     is_base_price_index,
     is_plain_inflation_request,
@@ -86,11 +88,6 @@ class ResolverService:
     """Resolve deterministic series mappings for the first workflow."""
 
     _SEARCH_CANDIDATE_LIMIT = 15
-    _SEMANTIC_PROFILES = {
-        "plain_inflation": {
-            "scorer_method": "_score_plain_inflation_profile",
-        },
-    }
     _RANKING_WEIGHTS = {
         "frequency_match": 1.75,
         "frequency_mismatch": 0.75,
@@ -187,21 +184,6 @@ class ResolverService:
         ]
 
     @classmethod
-    def _candidate_text(cls, candidate: SeriesSearchMatch) -> str:
-        return " ".join(
-            part
-            for part in [
-                candidate.series_id,
-                candidate.title,
-                candidate.units or "",
-                candidate.frequency or "",
-                candidate.seasonal_adjustment or "",
-                candidate.notes or "",
-            ]
-            if part
-        ).lower()
-
-    @classmethod
     def _frequency_score(cls, candidate: SeriesSearchMatch, *, query_text: str) -> float:
         normalized_frequency = (candidate.frequency or "").strip().lower()
         if not normalized_frequency:
@@ -231,12 +213,12 @@ class ResolverService:
         if normalized_geography in {"united states", "u.s.", "us", "national"}:
             return 0.0
 
-        candidate_text = cls._candidate_text(candidate)
+        candidate_text_value = candidate_text(candidate)
         geography_terms = cls._significant_terms(geography)
         if not geography_terms:
             return 0.0
 
-        matched_terms = sum(1 for term in geography_terms if term in candidate_text)
+        matched_terms = sum(1 for term in geography_terms if term in candidate_text_value)
         if matched_terms == len(geography_terms):
             return cls._RANKING_WEIGHTS["geography_exact_match"]
         if matched_terms > 0:
@@ -251,8 +233,8 @@ class ResolverService:
         if not phrase or phrase == "unknown_indicator":
             return 0.0
 
-        candidate_text = cls._candidate_text(candidate)
-        if phrase in candidate_text:
+        candidate_text_value = candidate_text(candidate)
+        if phrase in candidate_text_value:
             return cls._RANKING_WEIGHTS["indicator_exact_phrase_match"]
 
         terms = cls._significant_terms(indicator)
@@ -261,7 +243,7 @@ class ResolverService:
 
         title_text = f"{candidate.series_id} {candidate.title}".lower()
         title_matches = sum(1 for term in terms if term in title_text)
-        full_matches = sum(1 for term in terms if term in candidate_text)
+        full_matches = sum(1 for term in terms if term in candidate_text_value)
         if title_matches >= max(1, min(2, len(terms))):
             return cls._RANKING_WEIGHTS["indicator_title_term_match"]
         if full_matches >= max(1, min(2, len(terms))):
@@ -278,18 +260,19 @@ class ResolverService:
     ) -> float:
         score = 0.0
         search_variants = [value for value in [search_text, indicator] if value]
-        for profile_name in cls._semantic_profile_names(search_variants):
-            scorer_method_name = cls._SEMANTIC_PROFILES[profile_name]["scorer_method"]
-            scorer = getattr(cls, scorer_method_name)
+        for scorer in cls._semantic_profile_scorers(search_variants):
             score += scorer(candidate)
         return score
 
     @classmethod
-    def _semantic_profile_names(cls, search_variants: list[str]) -> list[str]:
-        profile_names: list[str] = []
+    def _semantic_profile_scorers(
+        cls,
+        search_variants: list[str],
+    ) -> list[Callable[[SeriesSearchMatch], float]]:
+        scorers: list[Callable[[SeriesSearchMatch], float]] = []
         if is_plain_inflation_request(search_variants):
-            profile_names.append("plain_inflation")
-        return profile_names
+            scorers.append(cls._score_plain_inflation_profile)
+        return scorers
 
     @classmethod
     def _score_plain_inflation_profile(cls, candidate: SeriesSearchMatch) -> float:
@@ -305,8 +288,8 @@ class ResolverService:
         elif candidate_features.has_pce:
             score += cls._RANKING_WEIGHTS["profile_plain_inflation_pce_bonus"]
 
-        candidate_text = cls._candidate_text(candidate)
-        if "breakeven" in candidate_text:
+        candidate_text_value = candidate_text(candidate)
+        if "breakeven" in candidate_text_value:
             score -= cls._RANKING_WEIGHTS["profile_plain_inflation_breakeven_penalty"]
         return score
 

--- a/src/fred_query/services/resolver_service.py
+++ b/src/fred_query/services/resolver_service.py
@@ -86,6 +86,11 @@ class ResolverService:
     """Resolve deterministic series mappings for the first workflow."""
 
     _SEARCH_CANDIDATE_LIMIT = 15
+    _SEMANTIC_PROFILES = {
+        "plain_inflation": {
+            "scorer_method": "_score_plain_inflation_profile",
+        },
+    }
     _RANKING_WEIGHTS = {
         "frequency_match": 1.75,
         "frequency_mismatch": 0.75,
@@ -95,11 +100,11 @@ class ResolverService:
         "indicator_exact_phrase_match": 2.5,
         "indicator_title_term_match": 2.0,
         "indicator_full_text_term_match": 1.0,
-        "plain_inflation_base_index_bonus": 3.0,
-        "plain_inflation_specialized_penalty": 2.0,
-        "plain_inflation_cpi_bonus": 1.0,
-        "plain_inflation_pce_bonus": 0.5,
-        "plain_inflation_breakeven_penalty": 2.0,
+        "profile_plain_inflation_base_index_bonus": 3.0,
+        "profile_plain_inflation_specialized_penalty": 2.0,
+        "profile_plain_inflation_cpi_bonus": 1.0,
+        "profile_plain_inflation_pce_bonus": 0.5,
+        "profile_plain_inflation_breakeven_penalty": 2.0,
         "search_rank_base_bonus": 2.0,
         "search_rank_decay": 0.15,
         "confidence_single_candidate": 0.72,
@@ -271,23 +276,39 @@ class ResolverService:
         search_text: str,
         indicator: str,
     ) -> float:
+        score = 0.0
         search_variants = [value for value in [search_text, indicator] if value]
+        for profile_name in cls._semantic_profile_names(search_variants):
+            scorer_method_name = cls._SEMANTIC_PROFILES[profile_name]["scorer_method"]
+            scorer = getattr(cls, scorer_method_name)
+            score += scorer(candidate)
+        return score
+
+    @classmethod
+    def _semantic_profile_names(cls, search_variants: list[str]) -> list[str]:
+        profile_names: list[str] = []
         if is_plain_inflation_request(search_variants):
-            score = 0.0
-            if is_base_price_index(candidate):
-                score += cls._RANKING_WEIGHTS["plain_inflation_base_index_bonus"]
-            if has_specialized_inflation_variant(candidate):
-                score -= cls._RANKING_WEIGHTS["plain_inflation_specialized_penalty"]
-            candidate_features = extract_candidate_features(candidate)
-            if candidate_features.has_cpi:
-                score += cls._RANKING_WEIGHTS["plain_inflation_cpi_bonus"]
-            elif candidate_features.has_pce:
-                score += cls._RANKING_WEIGHTS["plain_inflation_pce_bonus"]
-            candidate_text = cls._candidate_text(candidate)
-            if "breakeven" in candidate_text:
-                score -= cls._RANKING_WEIGHTS["plain_inflation_breakeven_penalty"]
-            return score
-        return 0.0
+            profile_names.append("plain_inflation")
+        return profile_names
+
+    @classmethod
+    def _score_plain_inflation_profile(cls, candidate: SeriesSearchMatch) -> float:
+        score = 0.0
+        if is_base_price_index(candidate):
+            score += cls._RANKING_WEIGHTS["profile_plain_inflation_base_index_bonus"]
+        if has_specialized_inflation_variant(candidate):
+            score -= cls._RANKING_WEIGHTS["profile_plain_inflation_specialized_penalty"]
+
+        candidate_features = extract_candidate_features(candidate)
+        if candidate_features.has_cpi:
+            score += cls._RANKING_WEIGHTS["profile_plain_inflation_cpi_bonus"]
+        elif candidate_features.has_pce:
+            score += cls._RANKING_WEIGHTS["profile_plain_inflation_pce_bonus"]
+
+        candidate_text = cls._candidate_text(candidate)
+        if "breakeven" in candidate_text:
+            score -= cls._RANKING_WEIGHTS["profile_plain_inflation_breakeven_penalty"]
+        return score
 
     def _rank_search_matches(
         self,

--- a/src/fred_query/services/series_match_scorer.py
+++ b/src/fred_query/services/series_match_scorer.py
@@ -536,18 +536,38 @@ def build_match_score_context(intent: QueryIntent) -> MatchScoreContext | None:
     if not search_text:
         return None
 
-    example_searches = extract_clarification_examples(intent.clarification_question)
+    return build_match_score_context_from_parts(
+        search_text=search_text,
+        clarification_question=intent.clarification_question,
+        original_query=(
+            None
+            if intent.task_type in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS)
+            else intent.original_query
+        ),
+    )
+
+
+def build_match_score_context_from_parts(
+    *,
+    search_text: str | None,
+    clarification_question: str | None = None,
+    original_query: str | None = None,
+) -> MatchScoreContext | None:
+    if not search_text:
+        return None
+
+    example_searches = extract_clarification_examples(clarification_question)
     search_variants: list[str] = []
     for value in [*example_searches, search_text]:
         normalized = value.strip()
         if normalized and normalized not in search_variants:
             search_variants.append(normalized)
 
-    context_texts = context_texts_for_intent(
-        intent,
-        search_text=search_text,
-        example_searches=example_searches,
-    )
+    context_texts = [search_text, *example_searches]
+    if clarification_question:
+        context_texts.insert(0, clarification_question)
+    if original_query:
+        context_texts.insert(0, original_query)
     anchor_terms = significant_terms(context_texts)
     query_text = " ".join(part for part in context_texts if part)
     return MatchScoreContext(

--- a/src/fred_query/services/series_match_scorer.py
+++ b/src/fred_query/services/series_match_scorer.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import re
+
+from fred_query.schemas.intent import QueryIntent, TaskType
+from fred_query.schemas.resolved_series import SeriesSearchMatch
+
+
+STOP_WORDS = {
+    "a",
+    "about",
+    "all",
+    "an",
+    "and",
+    "another",
+    "any",
+    "are",
+    "at",
+    "be",
+    "between",
+    "data",
+    "do",
+    "economy",
+    "economic",
+    "for",
+    "from",
+    "in",
+    "into",
+    "is",
+    "like",
+    "measure",
+    "me",
+    "of",
+    "on",
+    "or",
+    "question",
+    "relationship",
+    "series",
+    "show",
+    "since",
+    "than",
+    "that",
+    "the",
+    "this",
+    "to",
+    "use",
+    "used",
+    "want",
+    "what",
+    "which",
+    "would",
+    "you",
+}
+INSTRUMENT_TERMS = {
+    "bond",
+    "bonds",
+    "coupon",
+    "investment",
+    "maturity",
+    "note",
+    "notes",
+    "security",
+    "securities",
+    "treasury",
+    "yield",
+}
+GROWTH_RATE_TERMS = (
+    "% chg",
+    "annual rate",
+    "annualized",
+    "growth rate",
+    "percent change",
+    "rate of change",
+    "year over year",
+    "yr. ago",
+    "yoy",
+)
+REAL_TERMS = (
+    "constant dollar",
+    "constant dollars",
+    "inflation-adjusted",
+)
+NOMINAL_TERMS = (
+    "current dollar",
+    "current dollars",
+    "current-dollar",
+    "nominal",
+)
+PER_CAPITA_TERMS = (
+    "per capita",
+    "per-capita",
+)
+MARKET_BASED_TERMS = (
+    "breakeven",
+    "inflation compensation",
+    "inflation-indexed",
+    "market-based",
+)
+
+
+@dataclass(frozen=True)
+class QueryFeatures:
+    normalized_text: str
+    wants_real: bool
+    wants_nominal: bool
+    wants_growth_rate: bool
+    wants_per_capita: bool
+    wants_market_based: bool
+    wants_seasonally_adjusted: bool | None
+
+
+@dataclass(frozen=True)
+class CandidateFeatures:
+    normalized_text: str
+    has_real: bool
+    has_nominal: bool
+    has_growth_rate: bool
+    has_index_level: bool
+    has_per_capita: bool
+    has_market_based_signal: bool
+    has_instrument_terms: bool
+    has_core: bool
+    has_pce: bool
+    has_cpi: bool
+    has_trimmed_mean: bool
+    has_ppi: bool
+    has_deflator: bool
+
+
+@dataclass(frozen=True)
+class MatchScoreContext:
+    search_text: str | None
+    example_searches: tuple[str, ...]
+    search_variants: tuple[str, ...]
+    anchor_terms: tuple[str, ...]
+    query_features: QueryFeatures
+
+
+def tokenize(text: str | None) -> list[str]:
+    if not text:
+        return []
+    return re.findall(r"[A-Za-z0-9]+", text.lower())
+
+
+def significant_terms(texts: list[str]) -> list[str]:
+    seen: set[str] = set()
+    terms: list[str] = []
+    for text in texts:
+        for token in tokenize(text):
+            if len(token) < 3 or token in STOP_WORDS:
+                continue
+            if token in seen:
+                continue
+            seen.add(token)
+            terms.append(token)
+    return terms
+
+
+def extract_clarification_examples(question: str | None) -> list[str]:
+    if not question:
+        return []
+
+    source = question.strip()
+    if ":" in source:
+        source = source.split(":", maxsplit=1)[1]
+    else:
+        match = re.search(r"\bmean\b(?P<tail>.+)$", source, flags=re.IGNORECASE)
+        if match:
+            source = match.group("tail")
+
+    source = re.sub(r"\bor\s+another\b.*$", "", source, flags=re.IGNORECASE).strip(" ?.")
+    source = re.sub(r"\bor\s+", ", ", source, flags=re.IGNORECASE)
+
+    examples: list[str] = []
+    seen: set[str] = set()
+    for part in source.split(","):
+        cleaned = re.sub(r"^(and|or)\s+", "", part.strip(), flags=re.IGNORECASE).strip(" ?.")
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        if lowered.startswith("another") or lowered.startswith("other"):
+            continue
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        examples.append(cleaned)
+    return examples[:3]
+
+
+def clarification_search_text(intent: QueryIntent) -> str | None:
+    search_text = intent.search_text
+    if (
+        intent.task_type in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS)
+        and intent.clarification_target_index is not None
+        and intent.clarification_target_index < len(intent.search_texts)
+    ):
+        search_text = intent.search_texts[intent.clarification_target_index]
+    return search_text
+
+
+def context_texts_for_intent(
+    intent: QueryIntent,
+    *,
+    search_text: str,
+    example_searches: list[str],
+) -> list[str]:
+    texts = [
+        intent.clarification_question or "",
+        search_text,
+        *example_searches,
+    ]
+    if intent.task_type not in (TaskType.MULTI_SERIES_COMPARISON, TaskType.RELATIONSHIP_ANALYSIS):
+        texts.insert(0, intent.original_query or "")
+    return texts
+
+
+def text_has_any(text: str, terms: tuple[str, ...]) -> bool:
+    return any(term in text for term in terms)
+
+
+def normalized_text(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def has_real_signal(text: str) -> bool:
+    if text_has_any(text, REAL_TERMS):
+        return True
+    if re.search(r"\breal\b", text) is not None:
+        return True
+    return re.search(r"\bchained\b.+\bdollar", text) is not None
+
+
+def has_nominal_signal(text: str, *, has_real: bool | None = None) -> bool:
+    if text_has_any(text, NOMINAL_TERMS):
+        return True
+    if has_real is None:
+        has_real = has_real_signal(text)
+    if has_real:
+        return False
+    return re.search(r"\bdollars?\b", text) is not None
+
+
+def extract_query_features(text: str) -> QueryFeatures:
+    normalized = normalized_text(text)
+    wants_seasonally_adjusted: bool | None = None
+    if "not seasonally adjusted" in normalized:
+        wants_seasonally_adjusted = False
+    elif "seasonally adjusted" in normalized:
+        wants_seasonally_adjusted = True
+
+    return QueryFeatures(
+        normalized_text=normalized,
+        wants_real=has_real_signal(normalized),
+        wants_nominal=has_nominal_signal(normalized),
+        wants_growth_rate=text_has_any(normalized, GROWTH_RATE_TERMS),
+        wants_per_capita=text_has_any(normalized, PER_CAPITA_TERMS),
+        wants_market_based=text_has_any(normalized, MARKET_BASED_TERMS)
+        or any(term in normalized for term in INSTRUMENT_TERMS),
+        wants_seasonally_adjusted=wants_seasonally_adjusted,
+    )
+
+
+@lru_cache(maxsize=1024)
+def extract_candidate_features_from_text(text: str) -> CandidateFeatures:
+    has_growth_rate = text_has_any(text, GROWTH_RATE_TERMS)
+    has_real = has_real_signal(text)
+    return CandidateFeatures(
+        normalized_text=text,
+        has_real=has_real,
+        has_nominal=has_nominal_signal(text, has_real=has_real),
+        has_growth_rate=has_growth_rate,
+        has_index_level="index" in text and not has_growth_rate,
+        has_per_capita=text_has_any(text, PER_CAPITA_TERMS),
+        has_market_based_signal=text_has_any(text, MARKET_BASED_TERMS),
+        has_instrument_terms=any(term in text for term in INSTRUMENT_TERMS),
+        has_core=(
+            "core" in text
+            or "less food and energy" in text
+            or "excluding food and energy" in text
+        ),
+        has_pce=(
+            "personal consumption expenditures" in text
+            or re.search(r"\bpce\b", text) is not None
+        ),
+        has_cpi="consumer price index" in text or re.search(r"\bcpi\b", text) is not None,
+        has_trimmed_mean="trimmed mean" in text,
+        has_ppi="producer price" in text or re.search(r"\bppi\b", text) is not None,
+        has_deflator="deflator" in text,
+    )
+
+
+def candidate_text(candidate: SeriesSearchMatch) -> str:
+    return " ".join(
+        value
+        for value in [
+            candidate.series_id,
+            candidate.title,
+            candidate.units or "",
+            candidate.frequency or "",
+            candidate.seasonal_adjustment or "",
+            candidate.notes or "",
+        ]
+        if value
+    ).lower()
+
+
+def extract_candidate_features(candidate: SeriesSearchMatch) -> CandidateFeatures:
+    return extract_candidate_features_from_text(candidate_text(candidate))
+
+
+def candidate_is_seasonally_adjusted(candidate: SeriesSearchMatch) -> bool | None:
+    adjustment = (candidate.seasonal_adjustment or "").strip().lower()
+    if not adjustment:
+        return None
+    if "not seasonally adjusted" in adjustment or adjustment == "nsa":
+        return False
+    if "seasonally adjusted" in adjustment or adjustment in {"sa", "saar"}:
+        return True
+    return None
+
+
+def generic_score_adjustment(
+    candidate: SeriesSearchMatch,
+    candidate_features: CandidateFeatures,
+    *,
+    context: MatchScoreContext,
+) -> float:
+    score = 0.0
+    query_features = context.query_features
+
+    if query_features.wants_real:
+        if candidate_features.has_real:
+            score += 2.0
+        elif candidate_features.has_nominal:
+            score -= 1.5
+
+    if query_features.wants_nominal:
+        if candidate_features.has_nominal:
+            score += 2.0
+        elif candidate_features.has_real:
+            score -= 1.5
+
+    if query_features.wants_growth_rate:
+        if candidate_features.has_growth_rate:
+            score += 1.5
+        elif candidate_features.has_index_level:
+            score -= 0.5
+
+    if query_features.wants_per_capita:
+        if candidate_features.has_per_capita:
+            score += 1.5
+        else:
+            score -= 0.5
+
+    if query_features.wants_market_based:
+        if candidate_features.has_market_based_signal or candidate_features.has_instrument_terms:
+            score += 1.5
+    elif candidate_features.has_instrument_terms:
+        score -= 1.5
+
+    seasonally_adjusted = candidate_is_seasonally_adjusted(candidate)
+    if query_features.wants_seasonally_adjusted is True:
+        if seasonally_adjusted is True:
+            score += 1.0
+        elif seasonally_adjusted is False:
+            score -= 0.5
+    elif query_features.wants_seasonally_adjusted is False:
+        if seasonally_adjusted is False:
+            score += 1.0
+        elif seasonally_adjusted is True:
+            score -= 0.5
+
+    return score
+
+
+def is_plain_inflation_request(search_variants: list[str]) -> bool:
+    combined = " ".join(search_variants).lower()
+    if "inflation" not in combined:
+        return False
+    return not any(
+        term in combined
+        for term in (
+            "core",
+            "trimmed",
+            "breakeven",
+            "deflator",
+            "producer",
+            "annualized",
+            "year over year",
+        )
+    )
+
+
+def candidate_has_any(candidate: SeriesSearchMatch, terms: tuple[str, ...]) -> bool:
+    text = candidate_text(candidate)
+    return any(term in text for term in terms)
+
+
+def has_specialized_inflation_variant(candidate: SeriesSearchMatch) -> bool:
+    return candidate_has_any(
+        candidate,
+        (
+            "trimmed mean",
+            "core",
+            "excluding food and energy",
+            "less food and energy",
+            "annual rate",
+            "annualized",
+            "% chg",
+            "percent change",
+            "breakeven",
+            "inflation-indexed",
+            "producer price",
+            "deflator",
+        ),
+    )
+
+
+def is_base_price_index(candidate: SeriesSearchMatch) -> bool:
+    text = candidate_text(candidate)
+    if not (
+        "consumer price index" in text
+        or "personal consumption expenditures" in text
+        or re.search(r"\bcpi\b", text)
+        or re.search(r"\bpce\b", text)
+    ):
+        return False
+    return "index" in text and not has_specialized_inflation_variant(candidate)
+
+
+def inflation_profile_score_adjustment(
+    candidate: SeriesSearchMatch,
+    *,
+    context: MatchScoreContext,
+    candidate_features: CandidateFeatures,
+) -> float:
+    if not is_plain_inflation_request(list(context.search_variants)):
+        return 0.0
+
+    score = 0.0
+    if is_base_price_index(candidate):
+        score += 2.5
+    if has_specialized_inflation_variant(candidate):
+        score -= 2.0
+    if candidate_features.has_instrument_terms and not context.query_features.wants_market_based:
+        score -= 0.5
+    return score
+
+
+def score_candidate(
+    candidate: SeriesSearchMatch,
+    *,
+    context: MatchScoreContext,
+) -> float:
+    title_text = f"{candidate.series_id} {candidate.title}".lower()
+    full_text = " ".join(
+        [
+            candidate.series_id,
+            candidate.title,
+            candidate.notes or "",
+            candidate.units or "",
+            candidate.frequency or "",
+        ]
+    ).lower()
+
+    candidate_features = extract_candidate_features(candidate)
+    score = 0.0
+    title_matches = 0
+    for term in context.anchor_terms:
+        if term in title_text:
+            score += 3.0
+            title_matches += 1
+        elif term in full_text:
+            score += 1.0
+
+    for phrase in context.search_variants:
+        lowered_phrase = phrase.lower().strip()
+        if not lowered_phrase:
+            continue
+        if lowered_phrase in full_text:
+            score += 5.0
+            continue
+
+        phrase_terms = significant_terms([phrase])
+        if phrase_terms:
+            matched_terms = sum(1 for term in phrase_terms if term in title_text)
+            if matched_terms >= max(1, min(2, len(phrase_terms))):
+                score += 3.5
+
+    if candidate.popularity is not None:
+        score += min(candidate.popularity / 25.0, 2.0)
+
+    if title_matches == 0:
+        score -= 2.0
+
+    score += generic_score_adjustment(candidate, candidate_features, context=context)
+    score += inflation_profile_score_adjustment(
+        candidate,
+        context=context,
+        candidate_features=candidate_features,
+    )
+    return score
+
+
+def build_match_score_context(intent: QueryIntent) -> MatchScoreContext | None:
+    search_text = clarification_search_text(intent)
+    if not search_text:
+        return None
+
+    example_searches = extract_clarification_examples(intent.clarification_question)
+    search_variants: list[str] = []
+    for value in [*example_searches, search_text]:
+        normalized = value.strip()
+        if normalized and normalized not in search_variants:
+            search_variants.append(normalized)
+
+    context_texts = context_texts_for_intent(
+        intent,
+        search_text=search_text,
+        example_searches=example_searches,
+    )
+    anchor_terms = significant_terms(context_texts)
+    query_text = " ".join(part for part in context_texts if part)
+    return MatchScoreContext(
+        search_text=search_text,
+        example_searches=tuple(example_searches),
+        search_variants=tuple(search_variants),
+        anchor_terms=tuple(anchor_terms),
+        query_features=extract_query_features(query_text),
+    )

--- a/src/fred_query/services/series_match_scorer.py
+++ b/src/fred_query/services/series_match_scorer.py
@@ -98,6 +98,30 @@ MARKET_BASED_TERMS = (
     "inflation-indexed",
     "market-based",
 )
+SCORE_WEIGHTS = {
+    "query_wants_real_match": 2.0,
+    "query_wants_real_penalty": 1.5,
+    "query_wants_nominal_match": 2.0,
+    "query_wants_nominal_penalty": 1.5,
+    "query_wants_growth_match": 1.5,
+    "query_wants_growth_penalty": 0.5,
+    "query_wants_per_capita_match": 1.5,
+    "query_wants_per_capita_penalty": 0.5,
+    "query_wants_market_based_match": 1.5,
+    "unexpected_instrument_penalty": 1.5,
+    "seasonal_adjustment_match": 1.0,
+    "seasonal_adjustment_penalty": 0.5,
+    "inflation_base_index_bonus": 2.5,
+    "inflation_specialized_penalty": 2.0,
+    "inflation_unwanted_instrument_penalty": 0.5,
+    "anchor_term_title_match": 3.0,
+    "anchor_term_full_text_match": 1.0,
+    "exact_phrase_match": 5.0,
+    "partial_phrase_match": 3.5,
+    "popularity_divisor": 25.0,
+    "popularity_cap": 2.0,
+    "no_title_match_penalty": 2.0,
+}
 
 
 @dataclass(frozen=True)
@@ -332,45 +356,45 @@ def generic_score_adjustment(
 
     if query_features.wants_real:
         if candidate_features.has_real:
-            score += 2.0
+            score += SCORE_WEIGHTS["query_wants_real_match"]
         elif candidate_features.has_nominal:
-            score -= 1.5
+            score -= SCORE_WEIGHTS["query_wants_real_penalty"]
 
     if query_features.wants_nominal:
         if candidate_features.has_nominal:
-            score += 2.0
+            score += SCORE_WEIGHTS["query_wants_nominal_match"]
         elif candidate_features.has_real:
-            score -= 1.5
+            score -= SCORE_WEIGHTS["query_wants_nominal_penalty"]
 
     if query_features.wants_growth_rate:
         if candidate_features.has_growth_rate:
-            score += 1.5
+            score += SCORE_WEIGHTS["query_wants_growth_match"]
         elif candidate_features.has_index_level:
-            score -= 0.5
+            score -= SCORE_WEIGHTS["query_wants_growth_penalty"]
 
     if query_features.wants_per_capita:
         if candidate_features.has_per_capita:
-            score += 1.5
+            score += SCORE_WEIGHTS["query_wants_per_capita_match"]
         else:
-            score -= 0.5
+            score -= SCORE_WEIGHTS["query_wants_per_capita_penalty"]
 
     if query_features.wants_market_based:
         if candidate_features.has_market_based_signal or candidate_features.has_instrument_terms:
-            score += 1.5
+            score += SCORE_WEIGHTS["query_wants_market_based_match"]
     elif candidate_features.has_instrument_terms:
-        score -= 1.5
+        score -= SCORE_WEIGHTS["unexpected_instrument_penalty"]
 
     seasonally_adjusted = candidate_is_seasonally_adjusted(candidate)
     if query_features.wants_seasonally_adjusted is True:
         if seasonally_adjusted is True:
-            score += 1.0
+            score += SCORE_WEIGHTS["seasonal_adjustment_match"]
         elif seasonally_adjusted is False:
-            score -= 0.5
+            score -= SCORE_WEIGHTS["seasonal_adjustment_penalty"]
     elif query_features.wants_seasonally_adjusted is False:
         if seasonally_adjusted is False:
-            score += 1.0
+            score += SCORE_WEIGHTS["seasonal_adjustment_match"]
         elif seasonally_adjusted is True:
-            score -= 0.5
+            score -= SCORE_WEIGHTS["seasonal_adjustment_penalty"]
 
     return score
 
@@ -441,11 +465,11 @@ def inflation_profile_score_adjustment(
 
     score = 0.0
     if is_base_price_index(candidate):
-        score += 2.5
+        score += SCORE_WEIGHTS["inflation_base_index_bonus"]
     if has_specialized_inflation_variant(candidate):
-        score -= 2.0
+        score -= SCORE_WEIGHTS["inflation_specialized_penalty"]
     if candidate_features.has_instrument_terms and not context.query_features.wants_market_based:
-        score -= 0.5
+        score -= SCORE_WEIGHTS["inflation_unwanted_instrument_penalty"]
     return score
 
 
@@ -470,30 +494,33 @@ def score_candidate(
     title_matches = 0
     for term in context.anchor_terms:
         if term in title_text:
-            score += 3.0
+            score += SCORE_WEIGHTS["anchor_term_title_match"]
             title_matches += 1
         elif term in full_text:
-            score += 1.0
+            score += SCORE_WEIGHTS["anchor_term_full_text_match"]
 
     for phrase in context.search_variants:
         lowered_phrase = phrase.lower().strip()
         if not lowered_phrase:
             continue
         if lowered_phrase in full_text:
-            score += 5.0
+            score += SCORE_WEIGHTS["exact_phrase_match"]
             continue
 
         phrase_terms = significant_terms([phrase])
         if phrase_terms:
             matched_terms = sum(1 for term in phrase_terms if term in title_text)
             if matched_terms >= max(1, min(2, len(phrase_terms))):
-                score += 3.5
+                score += SCORE_WEIGHTS["partial_phrase_match"]
 
     if candidate.popularity is not None:
-        score += min(candidate.popularity / 25.0, 2.0)
+        score += min(
+            candidate.popularity / SCORE_WEIGHTS["popularity_divisor"],
+            SCORE_WEIGHTS["popularity_cap"],
+        )
 
     if title_matches == 0:
-        score -= 2.0
+        score -= SCORE_WEIGHTS["no_title_match_penalty"]
 
     score += generic_score_adjustment(candidate, candidate_features, context=context)
     score += inflation_profile_score_adjustment(

--- a/tests/test_resolver_service.py
+++ b/tests/test_resolver_service.py
@@ -282,11 +282,29 @@ class ResolverServiceTest(unittest.TestCase):
         self.assertEqual(metadata.series_id, "WINNER")
         self.assertEqual(resolved.score, 0.78)
 
-    def test_semantic_profile_names_detect_plain_inflation_profile(self) -> None:
-        self.assertEqual(
-            ResolverService._semantic_profile_names(["inflation united states", "inflation"]),
-            ["plain_inflation"],
+    def test_semantic_profile_scorers_detect_plain_inflation_profile(self) -> None:
+        scorers = ResolverService._semantic_profile_scorers(["inflation united states", "inflation"])
+
+        self.assertEqual(len(scorers), 1)
+        expected = ResolverService._score_plain_inflation_profile(
+            SeriesSearchMatch(
+                series_id="CPIAUCSL",
+                title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                units="Index 1982-1984=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/CPIAUCSL",
+            )
         )
+        actual = scorers[0](
+            SeriesSearchMatch(
+                series_id="CPIAUCSL",
+                title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                units="Index 1982-1984=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/CPIAUCSL",
+            )
+        )
+        self.assertEqual(actual, expected)
 
     def test_plain_inflation_profile_prefers_cpi_like_series_over_breakeven_series(self) -> None:
         cpi_score = ResolverService._score_plain_inflation_profile(

--- a/tests/test_resolver_service.py
+++ b/tests/test_resolver_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import unittest
+
+from fred_query.schemas.resolved_series import SeriesMetadata, SeriesSearchMatch
+from fred_query.services.resolver_service import ResolverService
+
+
+class _RankingFREDClient:
+    def __init__(self) -> None:
+        self.last_search_limit: int | None = None
+        self.metadata = {
+            "T10YIE": SeriesMetadata(
+                series_id="T10YIE",
+                title="10-Year Breakeven Inflation Rate",
+                units="Percent",
+                frequency="Daily",
+                source_url="https://fred.stlouisfed.org/series/T10YIE",
+            ),
+            "PCEPI": SeriesMetadata(
+                series_id="PCEPI",
+                title="Personal Consumption Expenditures: Chain-type Price Index",
+                units="Index 2017=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/PCEPI",
+            ),
+            "CPIAUCSL": SeriesMetadata(
+                series_id="CPIAUCSL",
+                title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                units="Index 1982-1984=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/CPIAUCSL",
+            ),
+            "GDP": SeriesMetadata(
+                series_id="GDP",
+                title="Gross Domestic Product",
+                units="Billions of Current Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDP",
+            ),
+            "A191RL1Q225SBEA": SeriesMetadata(
+                series_id="A191RL1Q225SBEA",
+                title="Real Gross Domestic Product",
+                units="Percent Change from Preceding Period",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/A191RL1Q225SBEA",
+            ),
+            "GDPC1": SeriesMetadata(
+                series_id="GDPC1",
+                title="Real Gross Domestic Product",
+                units="Billions of Chained 2017 Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDPC1",
+            ),
+            "UNRATE": SeriesMetadata(
+                series_id="UNRATE",
+                title="Unemployment Rate",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/UNRATE",
+            ),
+            "TXURN": SeriesMetadata(
+                series_id="TXURN",
+                title="Unemployment Rate in Texas",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/TXURN",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        self.last_search_limit = limit
+        lowered = search_text.lower()
+        if "inflation" in lowered:
+            return [
+                SeriesSearchMatch(
+                    series_id="T10YIE",
+                    title=self.metadata["T10YIE"].title,
+                    units=self.metadata["T10YIE"].units,
+                    frequency=self.metadata["T10YIE"].frequency,
+                    popularity=100,
+                    source_url=self.metadata["T10YIE"].source_url,
+                ),
+                SeriesSearchMatch(
+                    series_id="PCEPI",
+                    title=self.metadata["PCEPI"].title,
+                    units=self.metadata["PCEPI"].units,
+                    frequency=self.metadata["PCEPI"].frequency,
+                    popularity=88,
+                    source_url=self.metadata["PCEPI"].source_url,
+                ),
+                SeriesSearchMatch(
+                    series_id="CPIAUCSL",
+                    title=self.metadata["CPIAUCSL"].title,
+                    units=self.metadata["CPIAUCSL"].units,
+                    frequency=self.metadata["CPIAUCSL"].frequency,
+                    popularity=95,
+                    source_url=self.metadata["CPIAUCSL"].source_url,
+                ),
+            ]
+        if "gdp" in lowered:
+            return [
+                SeriesSearchMatch(
+                    series_id="GDP",
+                    title=self.metadata["GDP"].title,
+                    units=self.metadata["GDP"].units,
+                    frequency=self.metadata["GDP"].frequency,
+                    seasonal_adjustment=self.metadata["GDP"].seasonal_adjustment,
+                    popularity=94,
+                    source_url=self.metadata["GDP"].source_url,
+                ),
+                SeriesSearchMatch(
+                    series_id="A191RL1Q225SBEA",
+                    title=self.metadata["A191RL1Q225SBEA"].title,
+                    units=self.metadata["A191RL1Q225SBEA"].units,
+                    frequency=self.metadata["A191RL1Q225SBEA"].frequency,
+                    seasonal_adjustment=self.metadata["A191RL1Q225SBEA"].seasonal_adjustment,
+                    popularity=78,
+                    source_url=self.metadata["A191RL1Q225SBEA"].source_url,
+                ),
+                SeriesSearchMatch(
+                    series_id="GDPC1",
+                    title=self.metadata["GDPC1"].title,
+                    units=self.metadata["GDPC1"].units,
+                    frequency=self.metadata["GDPC1"].frequency,
+                    seasonal_adjustment=self.metadata["GDPC1"].seasonal_adjustment,
+                    popularity=91,
+                    source_url=self.metadata["GDPC1"].source_url,
+                ),
+            ]
+        return [
+            SeriesSearchMatch(
+                series_id="UNRATE",
+                title=self.metadata["UNRATE"].title,
+                units=self.metadata["UNRATE"].units,
+                frequency=self.metadata["UNRATE"].frequency,
+                seasonal_adjustment=self.metadata["UNRATE"].seasonal_adjustment,
+                popularity=95,
+                source_url=self.metadata["UNRATE"].source_url,
+            ),
+            SeriesSearchMatch(
+                series_id="TXURN",
+                title=self.metadata["TXURN"].title,
+                units=self.metadata["TXURN"].units,
+                frequency=self.metadata["TXURN"].frequency,
+                seasonal_adjustment=self.metadata["TXURN"].seasonal_adjustment,
+                popularity=72,
+                source_url=self.metadata["TXURN"].source_url,
+            ),
+        ]
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class ResolverServiceTest(unittest.TestCase):
+    def test_resolve_series_reranks_plain_inflation_queries_away_from_market_based_first_hit(self) -> None:
+        client = _RankingFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, search_match = resolver.resolve_series(
+            search_text="inflation united states",
+            geography="United States",
+            indicator="inflation",
+        )
+
+        self.assertEqual(client.last_search_limit, 15)
+        self.assertEqual(metadata.series_id, "CPIAUCSL")
+        self.assertEqual(search_match.series_id, "CPIAUCSL")
+        self.assertEqual(resolved.series_id, "CPIAUCSL")
+        self.assertIn("reranked FRED search candidates", resolved.resolution_reason)
+
+    def test_resolve_series_prefers_real_level_series_over_nominal_or_growth_first_hits(self) -> None:
+        client = _RankingFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, search_match = resolver.resolve_series(
+            search_text="real gdp united states",
+            geography="United States",
+            indicator="real gdp",
+        )
+
+        self.assertEqual(metadata.series_id, "GDPC1")
+        self.assertEqual(search_match.series_id, "GDPC1")
+        self.assertEqual(resolved.series_id, "GDPC1")
+
+    def test_resolve_series_uses_geography_signal_in_reranking(self) -> None:
+        client = _RankingFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, search_match = resolver.resolve_series(
+            search_text="texas unemployment rate",
+            geography="Texas",
+            indicator="unemployment rate",
+        )
+
+        self.assertEqual(metadata.series_id, "TXURN")
+        self.assertEqual(search_match.series_id, "TXURN")
+        self.assertEqual(resolved.geography, "Texas")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_resolver_service.py
+++ b/tests/test_resolver_service.py
@@ -282,6 +282,34 @@ class ResolverServiceTest(unittest.TestCase):
         self.assertEqual(metadata.series_id, "WINNER")
         self.assertEqual(resolved.score, 0.78)
 
+    def test_semantic_profile_names_detect_plain_inflation_profile(self) -> None:
+        self.assertEqual(
+            ResolverService._semantic_profile_names(["inflation united states", "inflation"]),
+            ["plain_inflation"],
+        )
+
+    def test_plain_inflation_profile_prefers_cpi_like_series_over_breakeven_series(self) -> None:
+        cpi_score = ResolverService._score_plain_inflation_profile(
+            SeriesSearchMatch(
+                series_id="CPIAUCSL",
+                title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                units="Index 1982-1984=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/CPIAUCSL",
+            )
+        )
+        breakeven_score = ResolverService._score_plain_inflation_profile(
+            SeriesSearchMatch(
+                series_id="T10YIE",
+                title="10-Year Breakeven Inflation Rate",
+                units="Percent",
+                frequency="Daily",
+                source_url="https://fred.stlouisfed.org/series/T10YIE",
+            )
+        )
+
+        self.assertGreater(cpi_score, breakeven_score)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_resolver_service.py
+++ b/tests/test_resolver_service.py
@@ -158,6 +158,47 @@ class _RankingFREDClient:
         return self.metadata[series_id]
 
 
+class _ConfidenceBandFREDClient:
+    def __init__(self) -> None:
+        self.metadata = {
+            "WINNER": SeriesMetadata(
+                series_id="WINNER",
+                title="Winner Series",
+                units="Index",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/WINNER",
+            ),
+            "RUNNERUP": SeriesMetadata(
+                series_id="RUNNERUP",
+                title="Runner-up Series",
+                units="Index",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/RUNNERUP",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        return [
+            SeriesSearchMatch(
+                series_id="WINNER",
+                title=self.metadata["WINNER"].title,
+                units=self.metadata["WINNER"].units,
+                frequency=self.metadata["WINNER"].frequency,
+                source_url=self.metadata["WINNER"].source_url,
+            ),
+            SeriesSearchMatch(
+                series_id="RUNNERUP",
+                title=self.metadata["RUNNERUP"].title,
+                units=self.metadata["RUNNERUP"].units,
+                frequency=self.metadata["RUNNERUP"].frequency,
+                source_url=self.metadata["RUNNERUP"].source_url,
+            ),
+        ]
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
 class ResolverServiceTest(unittest.TestCase):
     def test_resolve_series_reranks_plain_inflation_queries_away_from_market_based_first_hit(self) -> None:
         client = _RankingFREDClient()
@@ -202,6 +243,44 @@ class ResolverServiceTest(unittest.TestCase):
         self.assertEqual(metadata.series_id, "TXURN")
         self.assertEqual(search_match.series_id, "TXURN")
         self.assertEqual(resolved.geography, "Texas")
+
+    def test_confidence_from_rank_gap_uses_close_call_band(self) -> None:
+        confidence = ResolverService._confidence_from_rank_gap(
+            [
+                (10.0, SeriesSearchMatch(series_id="WINNER", title="Winner", source_url="https://fred.stlouisfed.org/series/WINNER")),
+                (8.5, SeriesSearchMatch(series_id="RUNNERUP", title="Runner-up", source_url="https://fred.stlouisfed.org/series/RUNNERUP")),
+            ]
+        )
+
+        self.assertEqual(confidence, 0.6)
+
+    def test_confidence_from_rank_gap_uses_clear_gap_band(self) -> None:
+        confidence = ResolverService._confidence_from_rank_gap(
+            [
+                (12.0, SeriesSearchMatch(series_id="WINNER", title="Winner", source_url="https://fred.stlouisfed.org/series/WINNER")),
+                (6.0, SeriesSearchMatch(series_id="RUNNERUP", title="Runner-up", source_url="https://fred.stlouisfed.org/series/RUNNERUP")),
+            ]
+        )
+
+        self.assertEqual(confidence, 0.92)
+
+    def test_resolve_series_uses_rank_gap_confidence_instead_of_absolute_score_scaling(self) -> None:
+        client = _ConfidenceBandFREDClient()
+        resolver = ResolverService(client)
+
+        resolver._rank_search_matches = lambda **_: [  # type: ignore[method-assign]
+            (11.0, SeriesSearchMatch(series_id="WINNER", title="Winner Series", source_url="https://fred.stlouisfed.org/series/WINNER")),
+            (8.2, SeriesSearchMatch(series_id="RUNNERUP", title="Runner-up Series", source_url="https://fred.stlouisfed.org/series/RUNNERUP")),
+        ]
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="winner query",
+            geography="United States",
+            indicator="winner",
+        )
+
+        self.assertEqual(metadata.series_id, "WINNER")
+        self.assertEqual(resolved.score, 0.78)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 search considers top 10-20 matches, scores by title/units/frequency/geography/query intent, and stops defaulting to raw first-hit behavior.