### PR TITLE
Add structured clarification and unsupported reason codes 

### DIFF
--- a/src/fred_query/api/models.py
+++ b/src/fred_query/api/models.py
@@ -6,7 +6,13 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, field_validator, model_validator
 
 from fred_query.api.follow_up_suggestions import build_follow_up_suggestions
-from fred_query.schemas.analysis import FollowUpSuggestion, QueryResponse, RoutedQueryResponse, RoutedQueryStatus
+from fred_query.schemas.analysis import (
+    FollowUpSuggestion,
+    QueryResponse,
+    RoutedQueryReason,
+    RoutedQueryResponse,
+    RoutedQueryStatus,
+)
 from fred_query.schemas.intent import QueryIntent
 from fred_query.schemas.resolved_series import SeriesSearchMatch
 
@@ -119,6 +125,7 @@ class ApiRoutedQueryResponse(BaseModel):
     session_id: str
     revision_id: str
     status: RoutedQueryStatus
+    reason: RoutedQueryReason | None = None
     answer_text: str
     intent: QueryIntent
     candidate_series: list[SeriesSearchMatch] = Field(default_factory=list)
@@ -138,6 +145,7 @@ class ApiRoutedQueryResponse(BaseModel):
             session_id=session_id,
             revision_id=revision_id,
             status=response.status,
+            reason=response.reason,
             answer_text=response.answer_text,
             intent=response.intent,
             candidate_series=response.candidate_series,

--- a/src/fred_query/schemas/analysis.py
+++ b/src/fred_query/schemas/analysis.py
@@ -119,10 +119,19 @@ class RoutedQueryStatus(str, Enum):
     UNSUPPORTED = "unsupported"
 
 
+class RoutedQueryReason(str, Enum):
+    AMBIGUOUS_SERIES = "ambiguous_series"
+    TOO_MANY_TARGETS = "too_many_targets"
+    NEEDS_THRESHOLD = "needs_threshold"
+    UNKNOWN_GEOGRAPHY = "unknown_geography"
+    UNSUPPORTED_ROUTE = "unsupported_route"
+
+
 class RoutedQueryResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     status: RoutedQueryStatus
+    reason: RoutedQueryReason | None = None
     intent: QueryIntent
     answer_text: str
     query_response: QueryResponse | None = None

--- a/src/fred_query/services/query_router.py
+++ b/src/fred_query/services/query_router.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-from fred_query.schemas.analysis import RoutedQueryResponse, RoutedQueryStatus
-from fred_query.schemas.intent import QueryIntent, TaskType
+from fred_query.schemas.analysis import RoutedQueryReason, RoutedQueryResponse, RoutedQueryStatus
+from fred_query.schemas.intent import GeographyType, QueryIntent, TaskType
 from fred_query.services.clarification_resolver import ClarificationResolver
 from fred_query.services.comparison_service import StateGDPComparisonService
 from fred_query.services.cross_section_service import CrossSectionService
@@ -30,6 +30,24 @@ class QueryRouter:
     @staticmethod
     def _default_start_date() -> date:
         return date.today() - timedelta(days=365 * 10)
+
+    @staticmethod
+    def _clarification_reason(intent: QueryIntent) -> RoutedQueryReason:
+        if intent.task_type == TaskType.STATE_GDP_COMPARISON or intent.planned_task_type == TaskType.STATE_GDP_COMPARISON:
+            if len(intent.geographies) > 2:
+                return RoutedQueryReason.TOO_MANY_TARGETS
+            if (
+                len(intent.geographies) < 2
+                or any(item.geography_type not in (GeographyType.STATE,) for item in intent.geographies)
+            ):
+                return RoutedQueryReason.UNKNOWN_GEOGRAPHY
+        return RoutedQueryReason.AMBIGUOUS_SERIES
+
+    @staticmethod
+    def _unsupported_reason(intent: QueryIntent) -> RoutedQueryReason:
+        if intent.planned_task_type == TaskType.CROSS_SECTION and intent.rank_limit is None and len(intent.geographies) > 25:
+            return RoutedQueryReason.NEEDS_THRESHOLD
+        return RoutedQueryReason.UNSUPPORTED_ROUTE
 
     @staticmethod
     def apply_selected_series(intent: QueryIntent, selected_series_ids: list[str | None] | None) -> QueryIntent:
@@ -77,6 +95,7 @@ class QueryRouter:
             candidate_series = self.clarification_resolver.build_candidates(intent)
             return RoutedQueryResponse(
                 status=RoutedQueryStatus.NEEDS_CLARIFICATION,
+                reason=self._clarification_reason(intent),
                 intent=intent,
                 answer_text=self.clarification_resolver.answer_text(intent, candidate_series=candidate_series),
                 candidate_series=candidate_series,
@@ -86,6 +105,7 @@ class QueryRouter:
             if len(intent.geographies) != 2:
                 return RoutedQueryResponse(
                     status=RoutedQueryStatus.NEEDS_CLARIFICATION,
+                    reason=self._clarification_reason(intent),
                     intent=intent,
                     answer_text="I need exactly two US states to run the GDP comparison.",
                 )
@@ -133,6 +153,7 @@ class QueryRouter:
 
         return RoutedQueryResponse(
             status=RoutedQueryStatus.UNSUPPORTED,
+            reason=self._unsupported_reason(intent),
             intent=intent,
             answer_text=(
                 "The parser understood the request, but there is no deterministic execution path for it yet. "

--- a/src/fred_query/services/query_router.py
+++ b/src/fred_query/services/query_router.py
@@ -12,6 +12,8 @@ from fred_query.services.single_series_service import SingleSeriesLookupService
 
 
 class QueryRouter:
+    _MAX_UNBOUNDED_CROSS_SECTION_GEOGRAPHIES = 25
+
     def __init__(
         self,
         *,
@@ -32,7 +34,19 @@ class QueryRouter:
         return date.today() - timedelta(days=365 * 10)
 
     @staticmethod
+    def _needs_cross_section_threshold(intent: QueryIntent) -> bool:
+        # More than 25 named geographies creates an unreadable unbounded cross-section;
+        # require an explicit rank_limit so the user chooses the display threshold.
+        return (
+            intent.planned_task_type == TaskType.CROSS_SECTION
+            and intent.rank_limit is None
+            and len(intent.geographies) > QueryRouter._MAX_UNBOUNDED_CROSS_SECTION_GEOGRAPHIES
+        )
+
+    @staticmethod
     def _clarification_reason(intent: QueryIntent) -> RoutedQueryReason:
+        if QueryRouter._needs_cross_section_threshold(intent):
+            return RoutedQueryReason.NEEDS_THRESHOLD
         if intent.task_type == TaskType.STATE_GDP_COMPARISON or intent.planned_task_type == TaskType.STATE_GDP_COMPARISON:
             if len(intent.geographies) > 2:
                 return RoutedQueryReason.TOO_MANY_TARGETS
@@ -45,7 +59,7 @@ class QueryRouter:
 
     @staticmethod
     def _unsupported_reason(intent: QueryIntent) -> RoutedQueryReason:
-        if intent.planned_task_type == TaskType.CROSS_SECTION and intent.rank_limit is None and len(intent.geographies) > 25:
+        if QueryRouter._needs_cross_section_threshold(intent):
             return RoutedQueryReason.NEEDS_THRESHOLD
         return RoutedQueryReason.UNSUPPORTED_ROUTE
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,6 +17,7 @@ from fred_query.errors import ConfigurationError
 from fred_query.schemas.analysis import (
     AnalysisResult,
     QueryResponse,
+    RoutedQueryReason,
     RoutedQueryResponse,
     RoutedQueryStatus,
     SeriesAnalysis,
@@ -208,6 +209,7 @@ class APITest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["status"], "completed")
+        self.assertIsNone(payload["reason"])
         self.assertTrue(payload["session_id"])
         self.assertTrue(payload["revision_id"])
         self.assertEqual(payload["plotly_figure"]["layout"]["title"]["text"], "Real GDP Comparison: California vs Texas")
@@ -304,6 +306,7 @@ class APITest(unittest.TestCase):
     def test_ask_clarification(self) -> None:
         routed = RoutedQueryResponse(
             status=RoutedQueryStatus.NEEDS_CLARIFICATION,
+            reason=RoutedQueryReason.AMBIGUOUS_SERIES,
             intent=QueryIntent(
                 task_type=TaskType.SINGLE_SERIES_LOOKUP,
                 clarification_needed=True,
@@ -337,6 +340,7 @@ class APITest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         payload = response.json()
         self.assertEqual(payload["status"], "needs_clarification")
+        self.assertEqual(payload["reason"], "ambiguous_series")
         self.assertTrue(payload["session_id"])
         self.assertEqual(payload["candidate_series"][0]["series_id"], "CPIAUCSL")
         self.assertEqual(payload["candidate_series"][0]["selection_label"], "Headline CPI")

--- a/tests/test_natural_language_query_service.py
+++ b/tests/test_natural_language_query_service.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 from datetime import date, datetime, timezone
 import unittest
 
-from fred_query.schemas.analysis import AnalysisResult, QueryResponse, RoutedQueryResponse, RoutedQueryStatus, SeriesAnalysis
+from fred_query.schemas.analysis import (
+    AnalysisResult,
+    QueryResponse,
+    RoutedQueryReason,
+    RoutedQueryResponse,
+    RoutedQueryStatus,
+    SeriesAnalysis,
+)
 from fred_query.schemas.chart import AxisSpec, ChartSpec, ChartTrace
 from fred_query.schemas.intent import (
     ComparisonMode,
@@ -415,6 +422,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("How has California GDP compared to Texas since 2019?")
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.answer_text, "Completed comparison.")
 
     def test_returns_clarification_with_candidates(self) -> None:
@@ -436,6 +444,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("Show inflation.")
 
         self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.AMBIGUOUS_SERIES)
         self.assertIn("CPI or PCE", response.answer_text)
         self.assertEqual(response.candidate_series[0].series_id, "CPIAUCSL")
 
@@ -458,6 +467,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("Show inflation.", selected_series_id="CPIAUCSL")
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.query_response.intent.series_id, "CPIAUCSL")
         self.assertFalse(response.query_response.intent.clarification_needed)
 
@@ -481,6 +491,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("What is the relationship between brent crude oil prices and inflation?")
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.answer_text, "Completed relationship analysis.")
 
     def test_clarification_candidates_prefer_question_examples_over_irrelevant_raw_search_hits(self) -> None:
@@ -506,6 +517,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("What is the relationship between Brent crude oil prices and inflation since 2010?")
 
         self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.AMBIGUOUS_SERIES)
         self.assertEqual(
             [candidate.series_id for candidate in response.candidate_series],
             ["CPIAUCSL", "PCEPI"],
@@ -538,6 +550,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("What is the relationship between Brent crude oil prices and inflation since 2010?")
 
         self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.AMBIGUOUS_SERIES)
         self.assertEqual(
             [candidate.series_id for candidate in response.candidate_series],
             ["SERIES1", "SERIES2"],
@@ -566,6 +579,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("What is the relationship between Brent crude oil prices and inflation since 2010?")
 
         self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.AMBIGUOUS_SERIES)
         self.assertEqual(
             [candidate.series_id for candidate in response.candidate_series],
             ["CPIAUCSL", "PCEPI", "PCETRIM12M159SFRBDAL"],
@@ -618,6 +632,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         response = service.ask("Rank the top 10 states by unemployment rate.")
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.answer_text, "Completed cross-section analysis.")
         self.assertEqual(response.query_response.chart.chart_type, "bar")
 
@@ -649,6 +664,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         )
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.query_response.intent.series_id, "UNRATE")
         self.assertEqual(response.query_response.intent.search_text, "unemployment rate")
         self.assertEqual(response.query_response.intent.start_date, date(2020, 1, 1))
@@ -683,6 +699,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         )
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.query_response.intent.task_type, TaskType.MULTI_SERIES_COMPARISON)
         self.assertEqual(response.query_response.intent.series_ids[0], "UNRATE")
         self.assertEqual(response.query_response.intent.search_texts, ["unemployment rate", "cpi"])
@@ -717,6 +734,7 @@ class NaturalLanguageQueryServiceTest(unittest.TestCase):
         )
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         self.assertEqual(response.query_response.intent.task_type, TaskType.CROSS_SECTION)
         self.assertEqual(response.query_response.intent.search_text, "unemployment rate")
         self.assertEqual(response.query_response.intent.cross_section_scope, CrossSectionScope.STATES)

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 import unittest
 
-from fred_query.schemas.analysis import AnalysisResult, QueryResponse, RoutedQueryStatus
+from fred_query.schemas.analysis import AnalysisResult, QueryResponse, RoutedQueryReason, RoutedQueryStatus
 from fred_query.schemas.chart import AxisSpec, ChartSpec
 from fred_query.schemas.intent import (
     ComparisonMode,
@@ -86,6 +86,7 @@ class QueryRouterTest(unittest.TestCase):
         response = router.route(intent, selected_series_ids=["UNRATE", "CPIAUCSL"])
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         assert relationship_service.last_intent is not None
         self.assertEqual(relationship_service.last_intent.series_ids, ["UNRATE", "CPIAUCSL"])
         self.assertFalse(relationship_service.last_intent.clarification_needed)
@@ -115,6 +116,7 @@ class QueryRouterTest(unittest.TestCase):
         response = router.route(intent)
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         assert relationship_service.last_intent is not None
         self.assertEqual(relationship_service.last_intent.task_type, TaskType.RELATIONSHIP_ANALYSIS)
 
@@ -141,8 +143,68 @@ class QueryRouterTest(unittest.TestCase):
         response = router.route(intent)
 
         self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
         assert relationship_service.last_intent is not None
         self.assertEqual(relationship_service.last_intent.task_type, TaskType.MULTI_SERIES_COMPARISON)
+
+    def test_state_gdp_clarification_uses_unknown_geography_reason_for_missing_state(self) -> None:
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=_CapturingRelationshipService(),
+        )
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            geographies=[Geography(name="California", geography_type=GeographyType.STATE)],
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.UNKNOWN_GEOGRAPHY)
+
+    def test_state_gdp_clarification_uses_too_many_targets_reason_for_extra_states(self) -> None:
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=_CapturingRelationshipService(),
+        )
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="Texas", geography_type=GeographyType.STATE),
+                Geography(name="New York", geography_type=GeographyType.STATE),
+            ],
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.TOO_MANY_TARGETS)
+
+    def test_unsupported_route_returns_machine_readable_reason(self) -> None:
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=_CapturingRelationshipService(),
+        )
+        intent = QueryIntent.model_construct(task_type="custom_task", query_plan=None)
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.UNSUPPORTED)
+        self.assertEqual(response.reason, RoutedQueryReason.UNSUPPORTED_ROUTE)
 
 
 if __name__ == "__main__":

--- a/tests/test_query_router.py
+++ b/tests/test_query_router.py
@@ -191,6 +191,29 @@ class QueryRouterTest(unittest.TestCase):
         self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
         self.assertEqual(response.reason, RoutedQueryReason.TOO_MANY_TARGETS)
 
+    def test_cross_section_clarification_uses_needs_threshold_reason_for_many_geographies(self) -> None:
+        router = QueryRouter(
+            clarification_resolver=_NoopClarificationResolver(),
+            state_gdp_service=_StubStateGDPService(),
+            cross_section_service=_StubCrossSectionService(),
+            single_series_service=_StubSingleSeriesService(),
+            relationship_service=_CapturingRelationshipService(),
+        )
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            clarification_needed=True,
+            geographies=[
+                Geography(name=f"Region {index}", geography_type=GeographyType.REGION)
+                for index in range(26)
+            ],
+            search_text="unemployment rate",
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.NEEDS_THRESHOLD)
+
     def test_unsupported_route_returns_machine_readable_reason(self) -> None:
         router = QueryRouter(
             clarification_resolver=_NoopClarificationResolver(),


### PR DESCRIPTION
acceptance: every non-completed route returns a machine-readable reason like too_many_targets, needs_threshold, ambiguous_series, or unknown_geography.