### PR TITLE
Add resolver and router deterministic fixture suites (EVAL-002)

### DIFF
--- a/tests/test_resolver_fixtures.py
+++ b/tests/test_resolver_fixtures.py
@@ -1,0 +1,561 @@
+"""Deterministic resolver fixture suite (EVAL-002).
+
+Covers ambiguity, geography hints, units/frequency preferences, and
+top-hit reranking without touching live FRED or OpenAI endpoints.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from fred_query.schemas.resolved_series import SeriesMetadata, SeriesSearchMatch
+from fred_query.services.resolver_service import ResolverService
+
+
+# ---------------------------------------------------------------------------
+# Shared mock FRED clients
+# ---------------------------------------------------------------------------
+
+class _AmbiguityFREDClient:
+    """Two candidates with a small score gap — resolver should still pick the
+    better match but report a low-confidence (close-call) score."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "FEDFUNDS": SeriesMetadata(
+                series_id="FEDFUNDS",
+                title="Federal Funds Effective Rate",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Not Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/FEDFUNDS",
+            ),
+            "DFF": SeriesMetadata(
+                series_id="DFF",
+                title="Federal Funds Effective Rate",
+                units="Percent",
+                frequency="Daily",
+                seasonal_adjustment="Not Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/DFF",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        return [
+            SeriesSearchMatch(
+                series_id="FEDFUNDS",
+                title=self.metadata["FEDFUNDS"].title,
+                units=self.metadata["FEDFUNDS"].units,
+                frequency=self.metadata["FEDFUNDS"].frequency,
+                seasonal_adjustment=self.metadata["FEDFUNDS"].seasonal_adjustment,
+                popularity=95,
+                source_url=self.metadata["FEDFUNDS"].source_url,
+            ),
+            SeriesSearchMatch(
+                series_id="DFF",
+                title=self.metadata["DFF"].title,
+                units=self.metadata["DFF"].units,
+                frequency=self.metadata["DFF"].frequency,
+                seasonal_adjustment=self.metadata["DFF"].seasonal_adjustment,
+                popularity=92,
+                source_url=self.metadata["DFF"].source_url,
+            ),
+        ]
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class _GeographyHintFREDClient:
+    """State-level and national candidates — geography signal should decide."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "UNRATE": SeriesMetadata(
+                series_id="UNRATE",
+                title="Unemployment Rate",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/UNRATE",
+            ),
+            "CAUR": SeriesMetadata(
+                series_id="CAUR",
+                title="Unemployment Rate in California",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/CAUR",
+            ),
+            "NYUR": SeriesMetadata(
+                series_id="NYUR",
+                title="Unemployment Rate in New York",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/NYUR",
+            ),
+            "FLUR": SeriesMetadata(
+                series_id="FLUR",
+                title="Unemployment Rate in Florida",
+                units="Percent",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/FLUR",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        lowered = search_text.lower()
+        if "california" in lowered:
+            return [
+                self._match("UNRATE"),
+                self._match("CAUR"),
+                self._match("NYUR"),
+            ]
+        if "new york" in lowered:
+            return [
+                self._match("UNRATE"),
+                self._match("NYUR"),
+                self._match("CAUR"),
+            ]
+        if "florida" in lowered:
+            return [
+                self._match("UNRATE"),
+                self._match("FLUR"),
+                self._match("CAUR"),
+            ]
+        return [self._match("UNRATE")]
+
+    def _match(self, series_id: str) -> SeriesSearchMatch:
+        m = self.metadata[series_id]
+        return SeriesSearchMatch(
+            series_id=m.series_id,
+            title=m.title,
+            units=m.units,
+            frequency=m.frequency,
+            seasonal_adjustment=m.seasonal_adjustment,
+            popularity=90,
+            source_url=m.source_url,
+        )
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class _FrequencyPreferenceFREDClient:
+    """Monthly vs quarterly GDP candidates — frequency hint should decide."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "GDP": SeriesMetadata(
+                series_id="GDP",
+                title="Gross Domestic Product",
+                units="Billions of Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDP",
+            ),
+            "GDPC1": SeriesMetadata(
+                series_id="GDPC1",
+                title="Real Gross Domestic Product",
+                units="Billions of Chained 2017 Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDPC1",
+            ),
+            "PCEPILFE": SeriesMetadata(
+                series_id="PCEPILFE",
+                title="Personal Consumption Expenditures Excluding Food and Energy (Chain-Type Price Index)",
+                units="Index 2017=100",
+                frequency="Monthly",
+                seasonal_adjustment="Seasonally Adjusted",
+                source_url="https://fred.stlouisfed.org/series/PCEPILFE",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        lowered = search_text.lower()
+        if "monthly" in lowered or "core pce" in lowered:
+            return [
+                self._match("GDP"),
+                self._match("PCEPILFE"),
+            ]
+        return [
+            self._match("GDP"),
+            self._match("GDPC1"),
+        ]
+
+    def _match(self, series_id: str) -> SeriesSearchMatch:
+        m = self.metadata[series_id]
+        return SeriesSearchMatch(
+            series_id=m.series_id,
+            title=m.title,
+            units=m.units,
+            frequency=m.frequency,
+            seasonal_adjustment=m.seasonal_adjustment,
+            popularity=85,
+            source_url=m.source_url,
+        )
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class _TopHitMistakeFREDClient:
+    """FRED search returns a market-instrument series as hit #1, but the user
+    wants the consumer-facing headline index.  The reranker should fix this."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "T5YIE": SeriesMetadata(
+                series_id="T5YIE",
+                title="5-Year Breakeven Inflation Rate",
+                units="Percent",
+                frequency="Daily",
+                source_url="https://fred.stlouisfed.org/series/T5YIE",
+            ),
+            "CPIAUCSL": SeriesMetadata(
+                series_id="CPIAUCSL",
+                title="Consumer Price Index for All Urban Consumers: All Items in U.S. City Average",
+                units="Index 1982-1984=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/CPIAUCSL",
+            ),
+            "PCEPI": SeriesMetadata(
+                series_id="PCEPI",
+                title="Personal Consumption Expenditures: Chain-type Price Index",
+                units="Index 2017=100",
+                frequency="Monthly",
+                source_url="https://fred.stlouisfed.org/series/PCEPI",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        return [
+            SeriesSearchMatch(
+                series_id="T5YIE",
+                title=self.metadata["T5YIE"].title,
+                units=self.metadata["T5YIE"].units,
+                frequency=self.metadata["T5YIE"].frequency,
+                popularity=100,
+                source_url=self.metadata["T5YIE"].source_url,
+            ),
+            SeriesSearchMatch(
+                series_id="CPIAUCSL",
+                title=self.metadata["CPIAUCSL"].title,
+                units=self.metadata["CPIAUCSL"].units,
+                frequency=self.metadata["CPIAUCSL"].frequency,
+                popularity=95,
+                source_url=self.metadata["CPIAUCSL"].source_url,
+            ),
+            SeriesSearchMatch(
+                series_id="PCEPI",
+                title=self.metadata["PCEPI"].title,
+                units=self.metadata["PCEPI"].units,
+                frequency=self.metadata["PCEPI"].frequency,
+                popularity=88,
+                source_url=self.metadata["PCEPI"].source_url,
+            ),
+        ]
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class _UnitsPreferenceFREDClient:
+    """Real vs nominal GDP — 'real gdp' query should prefer chained dollars."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "GDP": SeriesMetadata(
+                series_id="GDP",
+                title="Gross Domestic Product",
+                units="Billions of Current Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDP",
+            ),
+            "GDPC1": SeriesMetadata(
+                series_id="GDPC1",
+                title="Real Gross Domestic Product",
+                units="Billions of Chained 2017 Dollars",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/GDPC1",
+            ),
+            "A191RL1Q225SBEA": SeriesMetadata(
+                series_id="A191RL1Q225SBEA",
+                title="Real Gross Domestic Product",
+                units="Percent Change from Preceding Period",
+                frequency="Quarterly",
+                seasonal_adjustment="SAAR",
+                source_url="https://fred.stlouisfed.org/series/A191RL1Q225SBEA",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        return [
+            self._match("GDP", popularity=94),
+            self._match("A191RL1Q225SBEA", popularity=78),
+            self._match("GDPC1", popularity=91),
+        ]
+
+    def _match(self, series_id: str, *, popularity: int = 80) -> SeriesSearchMatch:
+        m = self.metadata[series_id]
+        return SeriesSearchMatch(
+            series_id=m.series_id,
+            title=m.title,
+            units=m.units,
+            frequency=m.frequency,
+            seasonal_adjustment=m.seasonal_adjustment,
+            popularity=popularity,
+            source_url=m.source_url,
+        )
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+class _StateGDPResolutionFREDClient:
+    """Supports deterministic state GDP series pattern resolution."""
+
+    def __init__(self) -> None:
+        self.metadata = {
+            "CARGSP": SeriesMetadata(
+                series_id="CARGSP",
+                title="Real Gross Domestic Product: All Industries in California",
+                units="Millions of Chained 2017 Dollars",
+                frequency="Annual",
+                source_url="https://fred.stlouisfed.org/series/CARGSP",
+            ),
+            "TXRGSP": SeriesMetadata(
+                series_id="TXRGSP",
+                title="Real Gross Domestic Product: All Industries in Texas",
+                units="Millions of Chained 2017 Dollars",
+                frequency="Annual",
+                source_url="https://fred.stlouisfed.org/series/TXRGSP",
+            ),
+        }
+
+    def search_series(self, search_text: str, limit: int = 5) -> list[SeriesSearchMatch]:
+        return []
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        return self.metadata[series_id]
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: ambiguity
+# ---------------------------------------------------------------------------
+
+class ResolverAmbiguityFixtures(unittest.TestCase):
+    """Close-call scenarios where two candidates are nearly equivalent."""
+
+    def test_close_candidates_still_pick_winner_and_report_close_call_confidence(self) -> None:
+        client = _AmbiguityFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="federal funds rate",
+            geography="United States",
+            indicator="federal funds rate",
+        )
+
+        self.assertIn(resolved.series_id, {"FEDFUNDS", "DFF"})
+        self.assertEqual(resolved.score, 0.6, "close-call gap should yield 0.6 confidence")
+
+    def test_single_candidate_returns_single_candidate_confidence_band(self) -> None:
+        confidence = ResolverService._confidence_from_rank_gap(
+            [
+                (10.0, SeriesSearchMatch(
+                    series_id="ONLY",
+                    title="Only Match",
+                    source_url="https://fred.stlouisfed.org/series/ONLY",
+                )),
+            ]
+        )
+
+        self.assertEqual(confidence, 0.72)
+
+    def test_moderate_gap_returns_moderate_confidence_band(self) -> None:
+        confidence = ResolverService._confidence_from_rank_gap(
+            [
+                (10.0, SeriesSearchMatch(
+                    series_id="W",
+                    title="Winner",
+                    source_url="https://fred.stlouisfed.org/series/W",
+                )),
+                (7.5, SeriesSearchMatch(
+                    series_id="R",
+                    title="Runner-up",
+                    source_url="https://fred.stlouisfed.org/series/R",
+                )),
+            ]
+        )
+
+        self.assertEqual(confidence, 0.78)
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: geography hints
+# ---------------------------------------------------------------------------
+
+class ResolverGeographyFixtures(unittest.TestCase):
+    """Geography signals should steer ranking toward the matching region."""
+
+    def test_california_geography_picks_california_series(self) -> None:
+        client = _GeographyHintFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="unemployment rate california",
+            geography="California",
+            indicator="unemployment rate",
+        )
+
+        self.assertEqual(resolved.series_id, "CAUR")
+        self.assertEqual(resolved.geography, "California")
+
+    def test_new_york_geography_picks_new_york_series(self) -> None:
+        client = _GeographyHintFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="unemployment rate new york",
+            geography="New York",
+            indicator="unemployment rate",
+        )
+
+        self.assertEqual(resolved.series_id, "NYUR")
+        self.assertEqual(resolved.geography, "New York")
+
+    def test_florida_geography_picks_florida_series(self) -> None:
+        client = _GeographyHintFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="unemployment rate florida",
+            geography="Florida",
+            indicator="unemployment rate",
+        )
+
+        self.assertEqual(resolved.series_id, "FLUR")
+        self.assertEqual(resolved.geography, "Florida")
+
+    def test_state_gdp_deterministic_pattern_resolves_california(self) -> None:
+        client = _StateGDPResolutionFREDClient()
+        resolver = ResolverService(client)
+
+        resolved = resolver.resolve_state_gdp_series("California")
+
+        self.assertEqual(resolved.series_id, "CARGSP")
+        self.assertEqual(resolved.geography, "California")
+        self.assertIn("CARGSP", resolved.resolution_reason)
+
+    def test_state_gdp_deterministic_pattern_resolves_texas(self) -> None:
+        client = _StateGDPResolutionFREDClient()
+        resolver = ResolverService(client)
+
+        resolved = resolver.resolve_state_gdp_series("Texas")
+
+        self.assertEqual(resolved.series_id, "TXRGSP")
+        self.assertEqual(resolved.geography, "Texas")
+        self.assertIn("TXRGSP", resolved.resolution_reason)
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: units and frequency preferences
+# ---------------------------------------------------------------------------
+
+class ResolverUnitsFrequencyFixtures(unittest.TestCase):
+    """Unit and frequency signals should influence ranking."""
+
+    def test_real_gdp_query_prefers_chained_dollar_level_series_over_nominal(self) -> None:
+        client = _UnitsPreferenceFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="real gdp united states",
+            geography="United States",
+            indicator="real gdp",
+        )
+
+        self.assertEqual(resolved.series_id, "GDPC1")
+        self.assertIn("Chained", metadata.units)
+
+    def test_real_gdp_query_does_not_pick_growth_rate_series(self) -> None:
+        client = _UnitsPreferenceFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, _, _ = resolver.resolve_series(
+            search_text="real gdp united states",
+            geography="United States",
+            indicator="real gdp",
+        )
+
+        self.assertNotEqual(resolved.series_id, "A191RL1Q225SBEA")
+
+    def test_monthly_frequency_hint_boosts_monthly_candidate(self) -> None:
+        client = _FrequencyPreferenceFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="monthly core pce price index",
+            geography="United States",
+            indicator="core pce",
+        )
+
+        self.assertEqual(metadata.frequency, "Monthly")
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: top-hit mistakes
+# ---------------------------------------------------------------------------
+
+class ResolverTopHitMistakeFixtures(unittest.TestCase):
+    """FRED returns a market-instrument series first, but the reranker should
+    pick the headline consumer price index instead."""
+
+    def test_plain_inflation_reranks_away_from_breakeven_first_hit(self) -> None:
+        client = _TopHitMistakeFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, metadata, _ = resolver.resolve_series(
+            search_text="inflation united states",
+            geography="United States",
+            indicator="inflation",
+        )
+
+        self.assertEqual(resolved.series_id, "CPIAUCSL")
+        self.assertIn("reranked FRED search candidates", resolved.resolution_reason)
+
+    def test_breakeven_not_selected_for_plain_inflation_with_geography_context(self) -> None:
+        client = _TopHitMistakeFREDClient()
+        resolver = ResolverService(client)
+
+        resolved, _, _ = resolver.resolve_series(
+            search_text="inflation united states",
+            geography="United States",
+            indicator="inflation",
+        )
+
+        self.assertNotEqual(resolved.series_id, "T5YIE")
+        self.assertEqual(resolved.series_id, "CPIAUCSL")
+
+    def test_plain_inflation_profile_scorer_penalizes_breakeven(self) -> None:
+        breakeven_score = ResolverService._score_plain_inflation_profile(
+            SeriesSearchMatch(
+                series_id="T5YIE",
+                title="5-Year Breakeven Inflation Rate",
+                units="Percent",
+                frequency="Daily",
+                source_url="https://fred.stlouisfed.org/series/T5YIE",
+            )
+        )
+
+        self.assertLess(breakeven_score, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_fixtures.py
+++ b/tests/test_router_fixtures.py
@@ -1,0 +1,507 @@
+"""Deterministic router fixture suite (EVAL-002).
+
+Covers completed, clarification, and unsupported routing paths.
+Each fixture asserts the machine-readable reason codes from QRY-003.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+import unittest
+
+from fred_query.schemas.analysis import (
+    AnalysisResult,
+    QueryResponse,
+    RoutedQueryReason,
+    RoutedQueryStatus,
+)
+from fred_query.schemas.chart import AxisSpec, ChartSpec
+from fred_query.schemas.intent import (
+    ComparisonMode,
+    Geography,
+    GeographyType,
+    QueryIntent,
+    QueryOperator,
+    QueryOutputMode,
+    QueryPlan,
+    QueryTimeScope,
+    TaskType,
+)
+from fred_query.schemas.resolved_series import SeriesSearchMatch
+from fred_query.services.clarification_resolver import ClarificationResolver
+from fred_query.services.query_router import QueryRouter
+
+
+# ---------------------------------------------------------------------------
+# Stub services (same pattern as existing test_query_router.py)
+# ---------------------------------------------------------------------------
+
+class _NoopClarificationResolver(ClarificationResolver):
+    def __init__(self) -> None:
+        pass
+
+    def build_candidates(self, intent: QueryIntent) -> list[SeriesSearchMatch]:
+        return []
+
+    def answer_text(self, intent: QueryIntent, *, candidate_series: list[object]) -> str:
+        return "clarification needed"
+
+
+class _CandidateClarificationResolver(ClarificationResolver):
+    """Returns pre-set candidates so tests can verify they flow through."""
+
+    def __init__(self, candidates: list[SeriesSearchMatch]) -> None:
+        self._candidates = candidates
+
+    def build_candidates(self, intent: QueryIntent) -> list[SeriesSearchMatch]:
+        return self._candidates
+
+    def answer_text(self, intent: QueryIntent, *, candidate_series: list[object]) -> str:
+        return f"Did you mean one of these {len(candidate_series)} options?"
+
+
+def _stub_chart() -> ChartSpec:
+    return ChartSpec(
+        title="Fixture",
+        x_axis=AxisSpec(title="Date"),
+        y_axis=AxisSpec(title="Value"),
+        source_note="Source: fixture",
+    )
+
+
+class _CapturingSingleSeriesService:
+    def __init__(self) -> None:
+        self.last_intent: QueryIntent | None = None
+
+    def lookup(self, intent: QueryIntent) -> QueryResponse:
+        self.last_intent = intent
+        return QueryResponse(
+            intent=intent,
+            analysis=AnalysisResult(coverage_start=date(2020, 1, 1), coverage_end=date(2024, 1, 1)),
+            chart=_stub_chart(),
+            answer_text="single series result",
+        )
+
+
+class _CapturingStateGDPService:
+    def __init__(self) -> None:
+        self.last_kwargs: dict[str, object] = {}
+
+    def compare(self, **kwargs: object) -> QueryResponse:
+        self.last_kwargs = kwargs
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="Texas", geography_type=GeographyType.STATE),
+            ],
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+        )
+        return QueryResponse(
+            intent=intent,
+            analysis=AnalysisResult(coverage_start=date(2014, 1, 1), coverage_end=date(2024, 1, 1)),
+            chart=_stub_chart(),
+            answer_text="state gdp comparison result",
+        )
+
+
+class _CapturingCrossSectionService:
+    def __init__(self) -> None:
+        self.last_intent: QueryIntent | None = None
+
+    def analyze(self, intent: QueryIntent) -> QueryResponse:
+        self.last_intent = intent
+        return QueryResponse(
+            intent=intent,
+            analysis=AnalysisResult(coverage_start=date(2023, 1, 1), coverage_end=date(2024, 1, 1)),
+            chart=_stub_chart(),
+            answer_text="cross section result",
+        )
+
+
+class _CapturingRelationshipService:
+    def __init__(self) -> None:
+        self.last_intent: QueryIntent | None = None
+
+    def analyze(self, intent: QueryIntent) -> QueryResponse:
+        self.last_intent = intent
+        return QueryResponse(
+            intent=intent,
+            analysis=AnalysisResult(coverage_start=date(2020, 1, 1), coverage_end=date(2024, 1, 1)),
+            chart=_stub_chart(),
+            answer_text="relationship result",
+        )
+
+
+class _StubStateGDPService:
+    def compare(self, **_: object) -> QueryResponse:
+        raise AssertionError("state GDP should not be called")
+
+
+class _StubCrossSectionService:
+    def analyze(self, intent: QueryIntent) -> QueryResponse:
+        raise AssertionError("cross-section should not be called")
+
+
+class _StubSingleSeriesService:
+    def lookup(self, intent: QueryIntent) -> QueryResponse:
+        raise AssertionError("single-series should not be called")
+
+
+class _StubRelationshipService:
+    def analyze(self, intent: QueryIntent) -> QueryResponse:
+        raise AssertionError("relationship should not be called")
+
+
+def _make_router(
+    *,
+    clarification_resolver: ClarificationResolver | None = None,
+    state_gdp_service: object | None = None,
+    cross_section_service: object | None = None,
+    single_series_service: object | None = None,
+    relationship_service: object | None = None,
+) -> QueryRouter:
+    return QueryRouter(
+        clarification_resolver=clarification_resolver or _NoopClarificationResolver(),
+        state_gdp_service=state_gdp_service or _StubStateGDPService(),
+        cross_section_service=cross_section_service or _StubCrossSectionService(),
+        single_series_service=single_series_service or _StubSingleSeriesService(),
+        relationship_service=relationship_service or _StubRelationshipService(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: completed routes
+# ---------------------------------------------------------------------------
+
+class RouterCompletedFixtures(unittest.TestCase):
+    """Routes that successfully dispatch to a downstream service."""
+
+    def test_single_series_lookup_completes_with_no_reason(self) -> None:
+        single_service = _CapturingSingleSeriesService()
+        router = _make_router(single_series_service=single_service)
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            search_text="unemployment rate",
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+        self.assertIsNotNone(response.query_response)
+        self.assertIsNotNone(single_service.last_intent)
+
+    def test_state_gdp_comparison_completes_with_two_states(self) -> None:
+        state_service = _CapturingStateGDPService()
+        router = _make_router(state_gdp_service=state_service)
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="Texas", geography_type=GeographyType.STATE),
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+        self.assertEqual(state_service.last_kwargs["state1"], "California")
+        self.assertEqual(state_service.last_kwargs["state2"], "Texas")
+
+    def test_cross_section_completes_with_bounded_geographies(self) -> None:
+        cross_service = _CapturingCrossSectionService()
+        router = _make_router(cross_section_service=cross_service)
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            search_text="unemployment rate",
+            geographies=[
+                Geography(name=f"State {i}", geography_type=GeographyType.STATE)
+                for i in range(10)
+            ],
+            rank_limit=5,
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+        self.assertIsNotNone(cross_service.last_intent)
+
+    def test_relationship_analysis_completes_for_two_series(self) -> None:
+        rel_service = _CapturingRelationshipService()
+        router = _make_router(relationship_service=rel_service)
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            search_texts=["unemployment rate", "inflation"],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+        self.assertIsNotNone(rel_service.last_intent)
+
+    def test_multi_series_comparison_completes(self) -> None:
+        rel_service = _CapturingRelationshipService()
+        router = _make_router(relationship_service=rel_service)
+        intent = QueryIntent(
+            task_type=TaskType.MULTI_SERIES_COMPARISON,
+            comparison_mode=ComparisonMode.MULTI_SERIES,
+            search_texts=["gdp", "unemployment rate"],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+
+    def test_selected_series_ids_resolve_clarification_and_complete(self) -> None:
+        rel_service = _CapturingRelationshipService()
+        router = _make_router(relationship_service=rel_service)
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            clarification_needed=True,
+            clarification_target_index=0,
+            search_texts=["unemployment", "inflation"],
+        )
+
+        response = router.route(intent, selected_series_ids=["UNRATE", "CPIAUCSL"])
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+        assert rel_service.last_intent is not None
+        self.assertEqual(rel_service.last_intent.series_ids, ["UNRATE", "CPIAUCSL"])
+        self.assertFalse(rel_service.last_intent.clarification_needed)
+
+    def test_query_plan_overrides_legacy_task_type_to_relationship(self) -> None:
+        rel_service = _CapturingRelationshipService()
+        router = _make_router(relationship_service=rel_service)
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            query_plan=QueryPlan(
+                subjects=["unemployment rate", "gdp"],
+                geographies=[],
+                time_scope=QueryTimeScope(),
+                operators=[QueryOperator.ANALYZE_RELATIONSHIP],
+                output_mode=QueryOutputMode.RELATIONSHIP,
+            ),
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            search_texts=["unemployment rate", "gdp"],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: clarification routes (with reason codes)
+# ---------------------------------------------------------------------------
+
+class RouterClarificationFixtures(unittest.TestCase):
+    """Routes that need user clarification, asserting QRY-003 reason codes."""
+
+    def test_ambiguous_single_series_returns_ambiguous_series_reason(self) -> None:
+        candidates = [
+            SeriesSearchMatch(
+                series_id="FEDFUNDS",
+                title="Federal Funds Effective Rate",
+                source_url="https://fred.stlouisfed.org/series/FEDFUNDS",
+            ),
+            SeriesSearchMatch(
+                series_id="DFF",
+                title="Federal Funds Effective Rate (Daily)",
+                source_url="https://fred.stlouisfed.org/series/DFF",
+            ),
+        ]
+        resolver = _CandidateClarificationResolver(candidates)
+        router = _make_router(clarification_resolver=resolver)
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            clarification_needed=True,
+            search_text="federal funds rate",
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.AMBIGUOUS_SERIES)
+        self.assertEqual(len(response.candidate_series), 2)
+
+    def test_state_gdp_with_one_state_returns_unknown_geography_reason(self) -> None:
+        router = _make_router()
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.UNKNOWN_GEOGRAPHY)
+
+    def test_state_gdp_with_three_states_returns_too_many_targets_reason(self) -> None:
+        router = _make_router()
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="Texas", geography_type=GeographyType.STATE),
+                Geography(name="New York", geography_type=GeographyType.STATE),
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.TOO_MANY_TARGETS)
+
+    def test_state_gdp_with_non_state_geography_returns_unknown_geography_reason(self) -> None:
+        router = _make_router()
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+                Geography(name="United States", geography_type=GeographyType.NATIONAL),
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.UNKNOWN_GEOGRAPHY)
+
+    def test_cross_section_with_26_unbounded_geographies_returns_needs_threshold_reason(self) -> None:
+        router = _make_router()
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            clarification_needed=True,
+            search_text="unemployment rate",
+            geographies=[
+                Geography(name=f"Region {i}", geography_type=GeographyType.REGION)
+                for i in range(26)
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.NEEDS_THRESHOLD)
+
+    def test_cross_section_with_25_geographies_does_not_trigger_threshold(self) -> None:
+        cross_service = _CapturingCrossSectionService()
+        router = _make_router(cross_section_service=cross_service)
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            search_text="unemployment rate",
+            geographies=[
+                Geography(name=f"Region {i}", geography_type=GeographyType.REGION)
+                for i in range(25)
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+
+    def test_cross_section_with_rank_limit_bypasses_threshold_check(self) -> None:
+        cross_service = _CapturingCrossSectionService()
+        router = _make_router(cross_section_service=cross_service)
+        intent = QueryIntent(
+            task_type=TaskType.CROSS_SECTION,
+            search_text="unemployment rate",
+            rank_limit=10,
+            geographies=[
+                Geography(name=f"Region {i}", geography_type=GeographyType.REGION)
+                for i in range(30)
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.COMPLETED)
+        self.assertIsNone(response.reason)
+
+    def test_clarification_response_includes_candidate_series(self) -> None:
+        candidates = [
+            SeriesSearchMatch(
+                series_id="UNRATE",
+                title="Unemployment Rate",
+                source_url="https://fred.stlouisfed.org/series/UNRATE",
+            ),
+        ]
+        resolver = _CandidateClarificationResolver(candidates)
+        router = _make_router(clarification_resolver=resolver)
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            clarification_needed=True,
+            search_text="unemployment",
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(len(response.candidate_series), 1)
+        self.assertEqual(response.candidate_series[0].series_id, "UNRATE")
+
+
+# ---------------------------------------------------------------------------
+# Fixture suite: unsupported routes (with reason codes)
+# ---------------------------------------------------------------------------
+
+class RouterUnsupportedFixtures(unittest.TestCase):
+    """Routes with no deterministic execution path."""
+
+    def test_unknown_task_type_returns_unsupported_route_reason(self) -> None:
+        router = _make_router()
+        intent = QueryIntent.model_construct(task_type="forecast_model", query_plan=None)
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.UNSUPPORTED)
+        self.assertEqual(response.reason, RoutedQueryReason.UNSUPPORTED_ROUTE)
+
+    def test_unsupported_response_has_human_readable_answer_text(self) -> None:
+        router = _make_router()
+        intent = QueryIntent.model_construct(task_type="custom_analysis", query_plan=None)
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.UNSUPPORTED)
+        self.assertEqual(response.reason, RoutedQueryReason.UNSUPPORTED_ROUTE)
+        self.assertIn("no deterministic execution path", response.answer_text)
+
+    def test_state_gdp_with_wrong_count_and_no_clarification_flag_still_clarifies(self) -> None:
+        router = _make_router()
+        intent = QueryIntent(
+            task_type=TaskType.STATE_GDP_COMPARISON,
+            clarification_needed=True,
+            comparison_mode=ComparisonMode.STATE_VS_STATE,
+            geographies=[
+                Geography(name="California", geography_type=GeographyType.STATE),
+            ],
+        )
+
+        response = router.route(intent)
+
+        self.assertEqual(response.status, RoutedQueryStatus.NEEDS_CLARIFICATION)
+        self.assertEqual(response.reason, RoutedQueryReason.UNKNOWN_GEOGRAPHY)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #27. Adds 32 new tests covering resolver ambiguity, geography hints, units/frequency preferences, top-hit reranking mistakes, and router completed/clarification/unsupported paths with QRY-003 reason code assertions.