### PR TITLE
Add series operators and refactor service

### DIFF
--- a/src/fred_query/services/operators/__init__.py
+++ b/src/fred_query/services/operators/__init__.py
@@ -1,0 +1,32 @@
+from fred_query.services.operators.models import (
+    HistoricalSummaryResult,
+    ResolvedSeriesResult,
+    SingleSeriesTransformPlan,
+    SingleSeriesTransformOutput,
+)
+from fred_query.services.operators.presentation import BuildChartOp, RenderAnswerOp
+from fred_query.services.operators.series import (
+    AlignSeriesOp,
+    ApplyTransformOp,
+    ComputeSeriesMetricsOp,
+    FetchRecessionPeriodsOp,
+    FetchSeriesObservationsOp,
+    RankSeriesOp,
+    ResolveSeriesOp,
+)
+
+__all__ = [
+    "AlignSeriesOp",
+    "ApplyTransformOp",
+    "BuildChartOp",
+    "ComputeSeriesMetricsOp",
+    "FetchRecessionPeriodsOp",
+    "FetchSeriesObservationsOp",
+    "HistoricalSummaryResult",
+    "RankSeriesOp",
+    "RenderAnswerOp",
+    "ResolvedSeriesResult",
+    "ResolveSeriesOp",
+    "SingleSeriesTransformPlan",
+    "SingleSeriesTransformOutput",
+]

--- a/src/fred_query/services/operators/models.py
+++ b/src/fred_query/services/operators/models.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+
+from fred_query.schemas.analysis import DerivedMetric, HistoricalSeriesContext, ObservationPoint
+from fred_query.schemas.intent import TransformType
+from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata, SeriesSearchMatch
+
+
+@dataclass(frozen=True)
+class ResolvedSeriesResult:
+    resolved_series: ResolvedSeries
+    metadata: SeriesMetadata
+    search_match: SeriesSearchMatch | None
+
+
+@dataclass(frozen=True)
+class SingleSeriesTransformPlan:
+    start_date: date
+    end_date: date | None
+    effective_transform: TransformType
+    normalize_chart: bool
+    periods_per_year: int
+    transform_window: int | None
+    warmup_periods: int
+    fetch_start_date: date
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SingleSeriesTransformOutput:
+    visible_observations: list[ObservationPoint]
+    transformed_observations: list[ObservationPoint] | None
+    normalized_observations: list[ObservationPoint] | None
+    analysis_basis: str | None
+    analysis_units: str | None
+    latest_value: float | None
+    latest_date: date | None
+    comparison_units: str | None
+    compare_on_transformed_series: bool
+    total_growth_pct: float | None
+    compound_annual_growth_rate_pct: float | None
+
+
+@dataclass(frozen=True)
+class HistoricalSummaryResult:
+    context: HistoricalSeriesContext | None
+    metrics: list[DerivedMetric]
+    warnings: list[str] = field(default_factory=list)

--- a/src/fred_query/services/operators/presentation.py
+++ b/src/fred_query/services/operators/presentation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from fred_query.schemas.analysis import AnalysisResult, SeriesAnalysis
+from fred_query.schemas.chart import ChartSpec, DateSpanAnnotation
+from fred_query.services.answer_service import AnswerService
+from fred_query.services.chart_service import ChartService
+
+
+class BuildChartOp:
+    def __init__(self, chart_service: ChartService) -> None:
+        self.chart_service = chart_service
+
+    def build_single_series_chart(
+        self,
+        *,
+        series_result: SeriesAnalysis,
+        start_year: int,
+        end_year: int,
+        normalize: bool,
+        recession_periods: list[DateSpanAnnotation],
+    ) -> ChartSpec:
+        return self.chart_service.build_single_series_chart(
+            series_result=series_result,
+            start_year=start_year,
+            end_year=end_year,
+            normalize=normalize,
+            recession_periods=recession_periods,
+        )
+
+
+class RenderAnswerOp:
+    def __init__(self, answer_service: AnswerService) -> None:
+        self.answer_service = answer_service
+
+    def render_single_series_answer(self, analysis: AnalysisResult, *, normalize: bool) -> str:
+        return self.answer_service.write_single_series_lookup(analysis, normalize=normalize)

--- a/src/fred_query/services/operators/series.py
+++ b/src/fred_query/services/operators/series.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fred_query.schemas.analysis import DerivedMetric, HistoricalSeriesContext, ObservationPoint, SeriesAnalysis
+from fred_query.schemas.chart import DateSpanAnnotation
+from fred_query.schemas.intent import QueryIntent, TransformType
+from fred_query.schemas.resolved_series import SeriesMetadata
+from fred_query.services.fred_client import FREDClient
+from fred_query.services.operators.models import (
+    HistoricalSummaryResult,
+    ResolvedSeriesResult,
+    SingleSeriesTransformPlan,
+    SingleSeriesTransformOutput,
+)
+from fred_query.services.resolver_service import ResolverService
+from fred_query.services.transform_service import TransformService
+
+
+class ResolveSeriesOp:
+    def __init__(self, resolver_service: ResolverService) -> None:
+        self.resolver_service = resolver_service
+
+    def for_single_series(self, intent: QueryIntent) -> ResolvedSeriesResult:
+        search_text = intent.search_text or " ".join(intent.indicators)
+        resolved_series, metadata, search_match = self.resolver_service.resolve_series(
+            explicit_series_id=intent.series_id,
+            search_text=search_text,
+            geography=intent.geographies[0].name if intent.geographies else "Unspecified",
+            indicator=intent.indicators[0] if intent.indicators else "unknown_indicator",
+        )
+        return ResolvedSeriesResult(
+            resolved_series=resolved_series,
+            metadata=metadata,
+            search_match=search_match,
+        )
+
+
+class FetchSeriesObservationsOp:
+    def __init__(self, resolver_service: ResolverService) -> None:
+        self.resolver_service = resolver_service
+
+    def fetch(
+        self,
+        series_id: str,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        frequency: str | None = None,
+        aggregation_method: str | None = None,
+        limit: int | None = None,
+        sort_order: str | None = None,
+        empty_result_message: str | None = None,
+    ) -> list[ObservationPoint]:
+        return self.resolver_service.get_required_observations(
+            series_id,
+            start_date=start_date,
+            end_date=end_date,
+            frequency=frequency,
+            aggregation_method=aggregation_method,
+            limit=limit,
+            sort_order=sort_order,
+            empty_result_message=empty_result_message,
+        )
+
+
+class ApplyTransformOp:
+    def __init__(self, transform_service: TransformService) -> None:
+        self.transform_service = transform_service
+
+    def plan_single_series(
+        self,
+        intent: QueryIntent,
+        *,
+        metadata: SeriesMetadata,
+        start_date: date,
+        end_date: date | None,
+    ) -> SingleSeriesTransformPlan:
+        effective_transform = (
+            TransformType.LEVEL if intent.transform == TransformType.NORMALIZED_INDEX else intent.transform
+        )
+        normalize_chart = intent.normalization or intent.transform == TransformType.NORMALIZED_INDEX
+        periods_per_year = self.transform_service.periods_per_year_for_frequency(metadata.frequency)
+        transform_window, transform_warnings = self.transform_service.resolve_transform_window(
+            transform=effective_transform,
+            frequency=metadata.frequency,
+            requested_window=intent.transform_window,
+        )
+        warmup_periods = self.transform_service.transform_warmup_periods(
+            transform=effective_transform,
+            periods_per_year=periods_per_year,
+            window=transform_window,
+        )
+        fetch_start_date = self.transform_service.subtract_periods(
+            start_date,
+            periods=warmup_periods,
+            frequency=metadata.frequency,
+        )
+        return SingleSeriesTransformPlan(
+            start_date=start_date,
+            end_date=end_date,
+            effective_transform=effective_transform,
+            normalize_chart=normalize_chart,
+            periods_per_year=periods_per_year,
+            transform_window=transform_window,
+            warmup_periods=warmup_periods,
+            fetch_start_date=fetch_start_date,
+            warnings=transform_warnings,
+        )
+
+    def apply_single_series(
+        self,
+        observations: list[ObservationPoint],
+        *,
+        metadata: SeriesMetadata,
+        plan: SingleSeriesTransformPlan,
+    ) -> SingleSeriesTransformOutput:
+        visible_observations = self.transform_service.filter_observations_by_date(
+            observations,
+            start_date=plan.start_date,
+            end_date=plan.end_date,
+        )
+        if not visible_observations:
+            raise ValueError(f"No observations returned for {metadata.series_id} in the requested display window.")
+
+        normalized_observations = None
+        transformed_observations = None
+        analysis_basis = None
+        analysis_units = None
+        total_growth = None
+        compound_annual_growth_rate = None
+
+        if plan.effective_transform == TransformType.LEVEL:
+            normalized_observations = (
+                self.transform_service.normalize_to_index(visible_observations) if plan.normalize_chart else None
+            )
+            latest_value, latest_date = self.transform_service.latest_value(visible_observations)
+            total_growth = self.transform_service.calculate_total_growth_pct(visible_observations)
+            compound_annual_growth_rate = self.transform_service.calculate_cagr_pct(visible_observations)
+            comparison_units = metadata.units
+            compare_on_transformed_series = False
+        else:
+            transform_result = self.transform_service.apply_single_series_transform(
+                observations,
+                transform=plan.effective_transform,
+                units=metadata.units,
+                frequency=metadata.frequency,
+                window=plan.transform_window,
+            )
+            transformed_observations = self.transform_service.filter_observations_by_date(
+                transform_result.observations or [],
+                start_date=plan.start_date,
+                end_date=plan.end_date,
+            )
+            if not transformed_observations:
+                basis_label = transform_result.basis or plan.effective_transform.value.replace("_", " ")
+                raise ValueError(f"I could not derive {basis_label} over the requested date range.")
+
+            analysis_basis = transform_result.basis
+            analysis_units = transform_result.units
+            latest_value, latest_date = self.transform_service.latest_value(transformed_observations)
+            comparison_units = analysis_units
+            compare_on_transformed_series = transform_result.compare_on_transformed_series
+
+        return SingleSeriesTransformOutput(
+            visible_observations=visible_observations,
+            transformed_observations=transformed_observations,
+            normalized_observations=normalized_observations,
+            analysis_basis=analysis_basis,
+            analysis_units=analysis_units,
+            latest_value=latest_value,
+            latest_date=latest_date,
+            comparison_units=comparison_units,
+            compare_on_transformed_series=compare_on_transformed_series,
+            total_growth_pct=total_growth,
+            compound_annual_growth_rate_pct=compound_annual_growth_rate,
+        )
+
+
+class AlignSeriesOp:
+    def __init__(self, transform_service: TransformService) -> None:
+        self.transform_service = transform_service
+
+    def align(
+        self,
+        first: list[ObservationPoint],
+        second: list[ObservationPoint],
+    ) -> tuple[list[ObservationPoint], list[ObservationPoint]]:
+        return self.transform_service.align_on_dates(first, second)
+
+
+class ComputeSeriesMetricsOp:
+    _HISTORICAL_LOOKBACK_YEARS = 50
+
+    def __init__(
+        self,
+        *,
+        transform_service: TransformService,
+        fetch_observations_op: FetchSeriesObservationsOp,
+    ) -> None:
+        self.transform_service = transform_service
+        self.fetch_observations_op = fetch_observations_op
+
+    @staticmethod
+    def _subtract_years(value: date, *, years: int) -> date:
+        try:
+            return value.replace(year=value.year - years)
+        except ValueError:
+            return value.replace(month=2, day=28, year=value.year - years)
+
+    @classmethod
+    def _historical_start_date(cls, *, start_date: date, latest_date: date) -> date:
+        return min(start_date, cls._subtract_years(latest_date, years=cls._HISTORICAL_LOOKBACK_YEARS))
+
+    @staticmethod
+    def _metric_unit_for_series(units: str | None) -> str | None:
+        normalized = (units or "").strip().lower()
+        if "percent" in normalized:
+            return "%"
+        if "basis point" in normalized or normalized == "bps":
+            return "bps"
+        return None
+
+    @classmethod
+    def _historical_metrics(
+        cls,
+        *,
+        units: str | None,
+        context: HistoricalSeriesContext | None,
+    ) -> list[DerivedMetric]:
+        if context is None or context.observation_count < 2:
+            return []
+
+        metric_unit = cls._metric_unit_for_series(units)
+        metrics: list[DerivedMetric] = []
+        if context.average_value is not None:
+            metrics.append(
+                DerivedMetric(
+                    name="historical_average",
+                    value=round(context.average_value, 4),
+                    unit=metric_unit,
+                    description=(
+                        f"Average across {context.observation_count} observations from "
+                        f"{context.start_date.isoformat()} to {context.end_date.isoformat()}."
+                    ),
+                )
+            )
+        if context.percentile_rank is not None:
+            metrics.append(
+                DerivedMetric(
+                    name="historical_percentile_rank",
+                    value=round(context.percentile_rank, 1),
+                    description="Latest reading's percentile rank within the extended history window.",
+                )
+            )
+        if context.max_value is not None and context.max_date is not None:
+            metrics.append(
+                DerivedMetric(
+                    name="historical_peak",
+                    value=round(context.max_value, 4),
+                    unit=metric_unit,
+                    description=(
+                        f"Highest observation in the extended window, reached on {context.max_date.isoformat()}."
+                    ),
+                )
+            )
+        if context.min_value is not None and context.min_date is not None:
+            metrics.append(
+                DerivedMetric(
+                    name="historical_trough",
+                    value=round(context.min_value, 4),
+                    unit=metric_unit,
+                    description=(
+                        f"Lowest observation in the extended window, reached on {context.min_date.isoformat()}."
+                    ),
+                )
+            )
+        return metrics
+
+    def summarize_historical_context(
+        self,
+        *,
+        series_id: str,
+        metadata: SeriesMetadata,
+        observations: list[ObservationPoint],
+        transform_plan: SingleSeriesTransformPlan,
+        transform_result: SingleSeriesTransformOutput,
+    ) -> HistoricalSummaryResult:
+        if transform_result.latest_date is None:
+            historical_series = self.transform_service.filter_observations_by_date(
+                observations,
+                start_date=transform_plan.start_date,
+                end_date=None,
+            )
+            context = self.transform_service.summarize_historical_context(historical_series)
+            return HistoricalSummaryResult(
+                context=context,
+                metrics=self._historical_metrics(units=transform_result.comparison_units, context=context),
+            )
+
+        historical_start = self._historical_start_date(
+            start_date=transform_plan.start_date,
+            latest_date=transform_result.latest_date,
+        )
+        historical_fetch_start = historical_start
+        warnings: list[str] = []
+        if transform_result.compare_on_transformed_series:
+            historical_fetch_start = self.transform_service.subtract_periods(
+                historical_start,
+                periods=transform_plan.warmup_periods,
+                frequency=metadata.frequency,
+            )
+
+        try:
+            historical_observations = self.fetch_observations_op.fetch(
+                series_id,
+                start_date=historical_fetch_start,
+                end_date=transform_result.latest_date,
+            )
+        except Exception:
+            historical_observations = observations
+            if observations and historical_fetch_start < observations[0].date:
+                warnings.append(
+                    "Extended historical context was unavailable, so comparisons use only the requested range."
+                )
+
+        historical_series = self.transform_service.filter_observations_by_date(
+            historical_observations,
+            start_date=historical_start,
+            end_date=transform_result.latest_date,
+        )
+        if transform_result.compare_on_transformed_series:
+            transformed_history = self.transform_service.apply_single_series_transform(
+                historical_observations,
+                transform=transform_plan.effective_transform,
+                units=metadata.units,
+                frequency=metadata.frequency,
+                window=transform_plan.transform_window,
+            )
+            history_basis = self.transform_service.filter_observations_by_date(
+                transformed_history.observations or [],
+                start_date=historical_start,
+                end_date=transform_result.latest_date,
+            )
+            if history_basis:
+                historical_series = history_basis
+            else:
+                warnings.append(
+                    "Historical transform context could not be derived cleanly, so context uses only the requested display window."
+                )
+                historical_series = (
+                    transform_result.transformed_observations
+                    or transform_result.visible_observations
+                )
+
+        context = self.transform_service.summarize_historical_context(historical_series)
+        return HistoricalSummaryResult(
+            context=context,
+            metrics=self._historical_metrics(units=transform_result.comparison_units, context=context),
+            warnings=warnings,
+        )
+
+
+class RankSeriesOp:
+    @staticmethod
+    def rank(
+        series_results: list[SeriesAnalysis],
+        *,
+        descending: bool,
+    ) -> list[SeriesAnalysis]:
+        return sorted(
+            series_results,
+            key=lambda result: result.latest_value if result.latest_value is not None else float("-inf"),
+            reverse=descending,
+        )
+
+
+class FetchRecessionPeriodsOp:
+    def __init__(self, *, fred_client: FREDClient, transform_service: TransformService) -> None:
+        self.fred_client = fred_client
+        self.transform_service = transform_service
+
+    def fetch(self, *, start_date: date, end_date: date) -> list[DateSpanAnnotation]:
+        try:
+            recession_observations = self.fred_client.get_series_observations(
+                "USREC",
+                start_date=start_date,
+                end_date=end_date,
+            )
+            return self.transform_service.derive_recession_periods(recession_observations)
+        except Exception:
+            return []

--- a/src/fred_query/services/single_series_service.py
+++ b/src/fred_query/services/single_series_service.py
@@ -5,7 +5,6 @@ from datetime import date, timedelta
 from fred_query.schemas.analysis import (
     AnalysisResult,
     DerivedMetric,
-    HistoricalSeriesContext,
     QueryIntent,
     QueryResponse,
     SeriesAnalysis,
@@ -13,6 +12,15 @@ from fred_query.schemas.analysis import (
 from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
 from fred_query.services.fred_client import FREDClient
+from fred_query.services.operators import (
+    ApplyTransformOp,
+    BuildChartOp,
+    ComputeSeriesMetricsOp,
+    FetchRecessionPeriodsOp,
+    FetchSeriesObservationsOp,
+    RenderAnswerOp,
+    ResolveSeriesOp,
+)
 from fred_query.services.resolver_service import ResolverService
 from fred_query.schemas.intent import TransformType
 from fred_query.services.transform_service import TransformService
@@ -21,8 +29,6 @@ from fred_query.services.vintage_analysis_service import VintageAnalysisService
 
 class SingleSeriesLookupService:
     """Deterministic single-series lookup based on a FRED series ID or search phrase."""
-
-    _HISTORICAL_LOOKBACK_YEARS = 50
 
     def __init__(
         self,
@@ -33,6 +39,13 @@ class SingleSeriesLookupService:
         chart_service: ChartService | None = None,
         answer_service: AnswerService | None = None,
         vintage_analysis_service: VintageAnalysisService | None = None,
+        resolve_series_op: ResolveSeriesOp | None = None,
+        fetch_observations_op: FetchSeriesObservationsOp | None = None,
+        apply_transform_op: ApplyTransformOp | None = None,
+        compute_metrics_op: ComputeSeriesMetricsOp | None = None,
+        fetch_recession_periods_op: FetchRecessionPeriodsOp | None = None,
+        build_chart_op: BuildChartOp | None = None,
+        render_answer_op: RenderAnswerOp | None = None,
     ) -> None:
         self.fred_client = fred_client
         self.resolver_service = resolver_service or ResolverService(fred_client)
@@ -43,262 +56,84 @@ class SingleSeriesLookupService:
         self.chart_service = chart_service or ChartService()
         self.answer_service = answer_service or AnswerService()
         self.vintage_analysis_service = vintage_analysis_service or VintageAnalysisService(fred_client)
+        self.resolve_series_op = resolve_series_op or ResolveSeriesOp(self.resolver_service)
+        self.fetch_observations_op = fetch_observations_op or FetchSeriesObservationsOp(self.resolver_service)
+        self.apply_transform_op = apply_transform_op or ApplyTransformOp(self.transform_service)
+        self.compute_metrics_op = compute_metrics_op or ComputeSeriesMetricsOp(
+            transform_service=self.transform_service,
+            fetch_observations_op=self.fetch_observations_op,
+        )
+        self.fetch_recession_periods_op = fetch_recession_periods_op or FetchRecessionPeriodsOp(
+            fred_client=fred_client,
+            transform_service=self.transform_service,
+        )
+        self.build_chart_op = build_chart_op or BuildChartOp(self.chart_service)
+        self.render_answer_op = render_answer_op or RenderAnswerOp(self.answer_service)
 
     @staticmethod
     def _default_start_date() -> date:
         return date.today() - timedelta(days=365 * 10)
 
-    @staticmethod
-    def _subtract_years(value: date, *, years: int) -> date:
-        try:
-            return value.replace(year=value.year - years)
-        except ValueError:
-            return value.replace(month=2, day=28, year=value.year - years)
-
-    @classmethod
-    def _historical_start_date(cls, *, start_date: date, latest_date: date) -> date:
-        return min(start_date, cls._subtract_years(latest_date, years=cls._HISTORICAL_LOOKBACK_YEARS))
-
-    @staticmethod
-    def _metric_unit_for_series(units: str | None) -> str | None:
-        normalized = (units or "").strip().lower()
-        if "percent" in normalized:
-            return "%"
-        if "basis point" in normalized or normalized == "bps":
-            return "bps"
-        return None
-
-    @classmethod
-    def _historical_metrics(
-        cls,
-        *,
-        units: str | None,
-        context: HistoricalSeriesContext | None,
-    ) -> list[DerivedMetric]:
-        if context is None or context.observation_count < 2:
-            return []
-
-        metric_unit = cls._metric_unit_for_series(units)
-        metrics: list[DerivedMetric] = []
-        if context.average_value is not None:
-            metrics.append(
-                DerivedMetric(
-                    name="historical_average",
-                    value=round(context.average_value, 4),
-                    unit=metric_unit,
-                    description=(
-                        f"Average across {context.observation_count} observations from "
-                        f"{context.start_date.isoformat()} to {context.end_date.isoformat()}."
-                    ),
-                )
-            )
-        if context.percentile_rank is not None:
-            metrics.append(
-                DerivedMetric(
-                    name="historical_percentile_rank",
-                    value=round(context.percentile_rank, 1),
-                    description="Latest reading's percentile rank within the extended history window.",
-                )
-            )
-        if context.max_value is not None and context.max_date is not None:
-            metrics.append(
-                DerivedMetric(
-                    name="historical_peak",
-                    value=round(context.max_value, 4),
-                    unit=metric_unit,
-                    description=(
-                        f"Highest observation in the extended window, reached on {context.max_date.isoformat()}."
-                    ),
-                )
-            )
-        if context.min_value is not None and context.min_date is not None:
-            metrics.append(
-                DerivedMetric(
-                    name="historical_trough",
-                    value=round(context.min_value, 4),
-                    unit=metric_unit,
-                    description=(
-                        f"Lowest observation in the extended window, reached on {context.min_date.isoformat()}."
-                    ),
-                )
-            )
-        return metrics
-
     def lookup(self, intent: QueryIntent) -> QueryResponse:
         response_intent = intent.model_copy(deep=True)
         start_date = intent.start_date or self._default_start_date()
         end_date = intent.end_date
-        effective_transform = (
-            TransformType.LEVEL if intent.transform == TransformType.NORMALIZED_INDEX else intent.transform
-        )
-        normalize_chart = intent.normalization or intent.transform == TransformType.NORMALIZED_INDEX
 
-        search_text = intent.search_text or " ".join(intent.indicators)
-        resolved_series, metadata, search_match = self.resolver_service.resolve_series(
-            explicit_series_id=intent.series_id,
-            search_text=search_text,
-            geography=intent.geographies[0].name if intent.geographies else "Unspecified",
-            indicator=intent.indicators[0] if intent.indicators else "unknown_indicator",
-        )
+        resolved = self.resolve_series_op.for_single_series(intent)
+        resolved_series = resolved.resolved_series
+        metadata = resolved.metadata
+        search_match = resolved.search_match
         response_intent.series_id = metadata.series_id
         if not response_intent.search_text:
             response_intent.search_text = search_match.title if search_match is not None else metadata.title
         if not response_intent.indicators:
             response_intent.indicators = [resolved_series.indicator]
 
-        periods_per_year = self.transform_planning_service.periods_per_year_for_frequency(metadata.frequency)
-        transform_window, transform_warnings = self.transform_planning_service.resolve_transform_window(
-            transform=effective_transform,
-            frequency=metadata.frequency,
-            requested_window=intent.transform_window,
-        )
-        warmup_periods = self.transform_planning_service.transform_warmup_periods(
-            transform=effective_transform,
-            periods_per_year=periods_per_year,
-            window=transform_window,
-        )
-        fetch_start_date = self.transform_planning_service.subtract_periods(
-            start_date,
-            periods=warmup_periods,
-            frequency=metadata.frequency,
-        )
-
-        observations = self.resolver_service.get_required_observations(
-            metadata.series_id,
-            start_date=fetch_start_date,
-            end_date=end_date,
-        )
-
-        warnings: list[str] = []
-        warnings.extend(transform_warnings)
-        historical_context = None
-        historical_metrics: list[DerivedMetric] = []
-        visible_observations = self.series_transform_service.filter_observations_by_date(
-            observations,
+        transform_plan = self.apply_transform_op.plan_single_series(
+            intent,
+            metadata=metadata,
             start_date=start_date,
             end_date=end_date,
         )
-        if not visible_observations:
-            raise ValueError(f"No observations returned for {metadata.series_id} in the requested display window.")
-
-        normalized_observations = None
-        transformed_observations = None
-        analysis_basis = None
-        analysis_units = None
-        total_growth = None
-
-        if effective_transform == TransformType.LEVEL:
-            normalized_observations = (
-                self.series_transform_service.normalize_to_index(visible_observations) if normalize_chart else None
-            )
-            latest_value, latest_date = self.series_statistics_service.latest_value(visible_observations)
-            total_growth = self.series_statistics_service.calculate_total_growth_pct(visible_observations)
-            comparison_units = metadata.units
-            compare_on_transformed_series = False
-        else:
-            transform_result = self.series_transform_service.apply_single_series_transform(
-                observations,
-                transform=effective_transform,
-                units=metadata.units,
-                frequency=metadata.frequency,
-                window=transform_window,
-            )
-            transformed_observations = self.series_transform_service.filter_observations_by_date(
-                transform_result.observations or [],
-                start_date=start_date,
-                end_date=end_date,
-            )
-            if not transformed_observations:
-                basis_label = transform_result.basis or effective_transform.value.replace("_", " ")
-                raise ValueError(f"I could not derive {basis_label} over the requested date range.")
-
-            analysis_basis = transform_result.basis
-            analysis_units = transform_result.units
-            latest_value, latest_date = self.series_statistics_service.latest_value(transformed_observations)
-            comparison_units = analysis_units
-            compare_on_transformed_series = transform_result.compare_on_transformed_series
-
-        historical_observations = observations
-        if latest_date is not None:
-            historical_start = self._historical_start_date(start_date=start_date, latest_date=latest_date)
-            historical_fetch_start = historical_start
-            if compare_on_transformed_series:
-                historical_fetch_start = self.transform_planning_service.subtract_periods(
-                    historical_start,
-                    periods=warmup_periods,
-                    frequency=metadata.frequency,
-                )
-            try:
-                historical_observations = self.resolver_service.get_required_observations(
-                    metadata.series_id,
-                    start_date=historical_fetch_start,
-                    end_date=latest_date,
-                )
-            except Exception:
-                historical_observations = observations
-                if historical_fetch_start < observations[0].date:
-                    warnings.append(
-                        "Extended historical context was unavailable, so comparisons use only the requested range."
-                    )
-
-        historical_series = self.series_transform_service.filter_observations_by_date(
-            historical_observations,
-            start_date=historical_start if latest_date is not None else start_date,
-            end_date=latest_date,
-        )
-        if compare_on_transformed_series:
-            transformed_history = self.series_transform_service.apply_single_series_transform(
-                historical_observations,
-                transform=effective_transform,
-                units=metadata.units,
-                frequency=metadata.frequency,
-                window=transform_window,
-            )
-            history_basis = self.series_transform_service.filter_observations_by_date(
-                transformed_history.observations or [],
-                start_date=historical_start if latest_date is not None else start_date,
-                end_date=latest_date,
-            )
-            if history_basis:
-                historical_series = history_basis
-            else:
-                warnings.append(
-                    "Historical transform context could not be derived cleanly, so context uses only the requested display window."
-                )
-                historical_series = transformed_observations or visible_observations
-
-        historical_context = self.series_statistics_service.summarize_historical_context(historical_series)
-        historical_metrics = self._historical_metrics(
-            units=comparison_units,
-            context=historical_context,
+        observations = self.fetch_observations_op.fetch(
+            metadata.series_id,
+            start_date=transform_plan.fetch_start_date,
+            end_date=end_date,
         )
 
-        recession_periods = []
-        try:
-            recession_observations = self.fred_client.get_series_observations(
-                "USREC",
-                start_date=visible_observations[0].date,
-                end_date=visible_observations[-1].date,
-            )
-            recession_periods = self.series_statistics_service.derive_recession_periods(recession_observations)
-        except Exception:
-            recession_periods = []
+        warnings = list(transform_plan.warnings)
+        transform_result = self.apply_transform_op.apply_single_series(
+            observations,
+            metadata=metadata,
+            plan=transform_plan,
+        )
+        historical_summary = self.compute_metrics_op.summarize_historical_context(
+            series_id=metadata.series_id,
+            metadata=metadata,
+            observations=observations,
+            transform_plan=transform_plan,
+            transform_result=transform_result,
+        )
+        warnings.extend(historical_summary.warnings)
+
+        recession_periods = self.fetch_recession_periods_op.fetch(
+            start_date=transform_result.visible_observations[0].date,
+            end_date=transform_result.visible_observations[-1].date,
+        )
 
         series_analysis = SeriesAnalysis(
             series=resolved_series,
-            observations=visible_observations,
-            transformed_observations=transformed_observations or normalized_observations,
-            historical_context=historical_context,
-            analysis_basis=analysis_basis,
-            analysis_units=analysis_units,
-            total_growth_pct=total_growth,
-            compound_annual_growth_rate_pct=(
-                self.series_statistics_service.calculate_cagr_pct(visible_observations)
-                if effective_transform == TransformType.LEVEL
-                else None
+            observations=transform_result.visible_observations,
+            transformed_observations=(
+                transform_result.transformed_observations or transform_result.normalized_observations
             ),
-            latest_value=latest_value,
-            latest_observation_date=latest_date,
+            historical_context=historical_summary.context,
+            analysis_basis=transform_result.analysis_basis,
+            analysis_units=transform_result.analysis_units,
+            total_growth_pct=transform_result.total_growth_pct,
+            compound_annual_growth_rate_pct=transform_result.compound_annual_growth_rate_pct,
+            latest_value=transform_result.latest_value,
+            latest_observation_date=transform_result.latest_date,
         )
         derived_metrics = [
             DerivedMetric(
@@ -307,15 +142,15 @@ class SingleSeriesLookupService:
                 description="The series selected for execution.",
             )
         ]
-        if analysis_basis:
+        if transform_result.analysis_basis:
             derived_metrics.append(
                 DerivedMetric(
                     name="analysis_basis",
-                    value=analysis_basis,
+                    value=transform_result.analysis_basis,
                     description="Transformation applied before charting and historical comparison.",
                 )
             )
-        if transform_window is not None and effective_transform in (
+        if transform_plan.transform_window is not None and transform_plan.effective_transform in (
             TransformType.ROLLING_AVERAGE,
             TransformType.ROLLING_STDDEV,
             TransformType.ROLLING_VOLATILITY,
@@ -323,22 +158,23 @@ class SingleSeriesLookupService:
             derived_metrics.append(
                 DerivedMetric(
                     name="applied_transform_window",
-                    value=transform_window,
+                    value=transform_plan.transform_window,
                     unit="observations",
                     description="Rolling window length used for the displayed transform.",
                 )
             )
+        display_observations = (
+            transform_result.transformed_observations
+            or transform_result.visible_observations
+            or transform_result.normalized_observations
+        )
         analysis = AnalysisResult(
             series_results=[series_analysis],
-            derived_metrics=derived_metrics + historical_metrics,
+            derived_metrics=derived_metrics + historical_summary.metrics,
             warnings=warnings,
-            latest_observation_date=latest_date,
-            coverage_start=(
-                (transformed_observations or visible_observations or normalized_observations)[0].date
-            ),
-            coverage_end=(
-                (transformed_observations or visible_observations or normalized_observations)[-1].date
-            ),
+            latest_observation_date=transform_result.latest_date,
+            coverage_start=display_observations[0].date,
+            coverage_end=display_observations[-1].date,
         )
 
         # Add vintage analysis if requested
@@ -380,12 +216,23 @@ class SingleSeriesLookupService:
                 # If vintage analysis fails, add a warning but continue
                 analysis.warnings.append(f"Vintage analysis unavailable: {str(e)}")
 
-        chart = self.chart_service.build_single_series_chart(
+        chart = self.build_chart_op.build_single_series_chart(
             series_result=series_analysis,
-            start_year=analysis.coverage_start.year if analysis.coverage_start else visible_observations[0].date.year,
-            end_year=analysis.coverage_end.year if analysis.coverage_end else visible_observations[-1].date.year,
-            normalize=normalize_chart,
+            start_year=(
+                analysis.coverage_start.year
+                if analysis.coverage_start
+                else transform_result.visible_observations[0].date.year
+            ),
+            end_year=(
+                analysis.coverage_end.year
+                if analysis.coverage_end
+                else transform_result.visible_observations[-1].date.year
+            ),
+            normalize=transform_plan.normalize_chart,
             recession_periods=recession_periods,
         )
-        answer_text = self.answer_service.write_single_series_lookup(analysis, normalize=normalize_chart)
+        answer_text = self.render_answer_op.render_single_series_answer(
+            analysis,
+            normalize=transform_plan.normalize_chart,
+        )
         return QueryResponse(intent=response_intent, analysis=analysis, chart=chart, answer_text=answer_text)

--- a/tests/test_series_operators.py
+++ b/tests/test_series_operators.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+import unittest
+
+from fred_query.schemas.analysis import ObservationPoint, SeriesAnalysis
+from fred_query.schemas.intent import QueryIntent, TaskType, TransformType
+from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata
+from fred_query.services.operators import (
+    ApplyTransformOp,
+    FetchSeriesObservationsOp,
+    RankSeriesOp,
+    ResolveSeriesOp,
+)
+from fred_query.services.resolver_service import ResolverService
+from fred_query.services.transform_service import TransformService
+
+
+class _OperatorFREDClient:
+    def __init__(self) -> None:
+        self.base_date = date(1970, 1, 1)
+
+    def get_series_metadata(self, series_id: str) -> SeriesMetadata:
+        if series_id == "SP500":
+            return SeriesMetadata(
+                series_id=series_id,
+                title="S&P 500",
+                units="Index",
+                frequency="Daily",
+                seasonal_adjustment="NSA",
+                source_url=f"https://fred.stlouisfed.org/series/{series_id}",
+            )
+        return SeriesMetadata(
+            series_id=series_id,
+            title="Unemployment Rate",
+            units="Percent",
+            frequency="Monthly",
+            seasonal_adjustment="SA",
+            source_url=f"https://fred.stlouisfed.org/series/{series_id}",
+        )
+
+    def _value_for_date(self, current_date: date) -> float:
+        offset = (current_date - self.base_date).days
+        return 1000.0 + (offset * 0.25) + ((offset % 7) * 4.0)
+
+    def get_series_observations(
+        self,
+        series_id: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        *,
+        frequency: str | None = None,
+        aggregation_method: str | None = None,
+        limit: int | None = None,
+        sort_order: str | None = None,
+    ) -> list[ObservationPoint]:
+        if series_id != "SP500":
+            return [
+                ObservationPoint(date=date(2024, 1, 1), value=3.9),
+                ObservationPoint(date=date(2024, 2, 1), value=4.0),
+            ]
+
+        current_date = start_date or date(2024, 1, 1)
+        final_date = end_date or date(2024, 2, 15)
+        observations: list[ObservationPoint] = []
+        while current_date <= final_date:
+            observations.append(ObservationPoint(date=current_date, value=self._value_for_date(current_date)))
+            current_date += timedelta(days=1)
+        return observations
+
+
+class SeriesOperatorsTest(unittest.TestCase):
+    def test_resolve_series_op_uses_resolver_service_for_explicit_series_id(self) -> None:
+        resolver = ResolverService(_OperatorFREDClient())
+        op = ResolveSeriesOp(resolver)
+        intent = QueryIntent(task_type=TaskType.SINGLE_SERIES_LOOKUP, series_id="UNRATE")
+
+        result = op.for_single_series(intent)
+
+        self.assertEqual(result.metadata.series_id, "UNRATE")
+        self.assertEqual(result.resolved_series.series_id, "UNRATE")
+        self.assertIsNone(result.search_match)
+
+    def test_fetch_observations_op_delegates_required_observation_fetch(self) -> None:
+        resolver = ResolverService(_OperatorFREDClient())
+        op = FetchSeriesObservationsOp(resolver)
+
+        observations = op.fetch("UNRATE", start_date=date(2024, 1, 1), end_date=date(2024, 2, 1))
+
+        self.assertEqual([point.date for point in observations], [date(2024, 1, 1), date(2024, 2, 1)])
+
+    def test_apply_transform_op_plans_warmup_and_applies_visible_transform(self) -> None:
+        transform_service = TransformService()
+        op = ApplyTransformOp(transform_service)
+        metadata = SeriesMetadata(
+            series_id="SP500",
+            title="S&P 500",
+            units="Index",
+            frequency="Daily",
+            seasonal_adjustment="NSA",
+            source_url="https://fred.stlouisfed.org/series/SP500",
+        )
+        intent = QueryIntent(
+            task_type=TaskType.SINGLE_SERIES_LOOKUP,
+            series_id="SP500",
+            start_date=date(2024, 2, 1),
+            transform=TransformType.ROLLING_VOLATILITY,
+        )
+
+        plan = op.plan_single_series(
+            intent,
+            metadata=metadata,
+            start_date=date(2024, 2, 1),
+            end_date=None,
+        )
+        observations = _OperatorFREDClient().get_series_observations("SP500", start_date=plan.fetch_start_date)
+        result = op.apply_single_series(observations, metadata=metadata, plan=plan)
+
+        self.assertEqual(plan.transform_window, 30)
+        self.assertEqual(plan.fetch_start_date, date(2024, 1, 2))
+        self.assertEqual(result.analysis_basis, "30-observation rolling annualized volatility")
+        self.assertEqual(result.transformed_observations[0].date, date(2024, 2, 1))
+
+    def test_rank_series_op_orders_by_latest_value(self) -> None:
+        first = SeriesAnalysis(
+            series=ResolvedSeries(
+                series_id="A",
+                title="A",
+                geography="A",
+                indicator="test",
+                units="Percent",
+                frequency="M",
+                resolution_reason="fixture",
+                source_url="https://fred.stlouisfed.org/series/A",
+            ),
+            latest_value=1.0,
+        )
+        second = first.model_copy(
+            update={
+                "series": first.series.model_copy(update={"series_id": "B", "title": "B"}),
+                "latest_value": 2.0,
+            }
+        )
+
+        ranked = RankSeriesOp.rank([first, second], descending=True)
+
+        self.assertEqual([item.series.series_id for item in ranked], ["B", "A"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce a new fred_query.services.operators package (models, presentation, series) that encapsulates series resolution, observation fetching, transforms, alignment, metrics computation, ranking, and recession period derivation. Refactor SingleSeriesLookupService to depend on these operator classes (via dependency injection) and delegate transform planning, observation fetching, metrics summarization, chart building, and answer rendering to the new ops. Add unit tests for the operator behaviors (tests/test_series_operators.py). This decouples responsibilities, simplifies the single-series flow, and improves testability.