### PR TITLE
Introduce relationship operators and models

### DIFF
--- a/src/fred_query/services/operators/__init__.py
+++ b/src/fred_query/services/operators/__init__.py
@@ -1,6 +1,9 @@
 from fred_query.services.operators.models import (
     HistoricalSummaryResult,
     ResolvedSeriesResult,
+    RelationshipMetricsResult,
+    RelationshipSeriesTransformOutput,
+    RelationshipTransformPlan,
     SingleSeriesTransformPlan,
     SingleSeriesTransformOutput,
 )
@@ -8,6 +11,7 @@ from fred_query.services.operators.presentation import BuildChartOp, RenderAnswe
 from fred_query.services.operators.series import (
     AlignSeriesOp,
     ApplyTransformOp,
+    ComputeRelationshipMetricsOp,
     ComputeSeriesMetricsOp,
     FetchRecessionPeriodsOp,
     FetchSeriesObservationsOp,
@@ -19,6 +23,7 @@ __all__ = [
     "AlignSeriesOp",
     "ApplyTransformOp",
     "BuildChartOp",
+    "ComputeRelationshipMetricsOp",
     "ComputeSeriesMetricsOp",
     "FetchRecessionPeriodsOp",
     "FetchSeriesObservationsOp",
@@ -27,6 +32,9 @@ __all__ = [
     "RenderAnswerOp",
     "ResolvedSeriesResult",
     "ResolveSeriesOp",
+    "RelationshipMetricsResult",
+    "RelationshipSeriesTransformOutput",
+    "RelationshipTransformPlan",
     "SingleSeriesTransformPlan",
     "SingleSeriesTransformOutput",
 ]

--- a/src/fred_query/services/operators/models.py
+++ b/src/fred_query/services/operators/models.py
@@ -44,6 +44,42 @@ class SingleSeriesTransformOutput:
 
 
 @dataclass(frozen=True)
+class RelationshipTransformPlan:
+    start_date: date
+    end_date: date | None
+    frequency_code: str
+    frequency_label: str
+    periods_per_year: int
+    lag_unit: str
+    requested_transform: TransformType
+    effective_transform: TransformType
+    normalization: bool
+    transform_window: int | None
+    warmup_periods: int
+    fetch_start_date: date
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RelationshipSeriesTransformOutput:
+    visible_observations: list[ObservationPoint]
+    transformed_observations: list[ObservationPoint]
+    basis: str
+    units: str
+    applied_transform_window: int | None
+    warnings: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RelationshipMetricsResult:
+    same_period_correlation: float | None
+    regression_slope: float | None
+    best_lag: int | None
+    best_lag_correlation: float | None
+    best_lag_samples: int
+
+
+@dataclass(frozen=True)
 class HistoricalSummaryResult:
     context: HistoricalSeriesContext | None
     metrics: list[DerivedMetric]

--- a/src/fred_query/services/operators/presentation.py
+++ b/src/fred_query/services/operators/presentation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import date
+
 from fred_query.schemas.analysis import AnalysisResult, SeriesAnalysis
 from fred_query.schemas.chart import ChartSpec, DateSpanAnnotation
 from fred_query.services.answer_service import AnswerService
@@ -27,6 +29,25 @@ class BuildChartOp:
             recession_periods=recession_periods,
         )
 
+    def build_relationship_chart(
+        self,
+        *,
+        series_results: list[SeriesAnalysis],
+        frequency_label: str,
+        chart_basis: str,
+        chart_units: str,
+        start_date: date,
+        end_date: date,
+    ) -> ChartSpec:
+        return self.chart_service.build_relationship_chart(
+            series_results=series_results,
+            frequency_label=frequency_label,
+            chart_basis=chart_basis,
+            chart_units=chart_units,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
 
 class RenderAnswerOp:
     def __init__(self, answer_service: AnswerService) -> None:
@@ -34,3 +55,6 @@ class RenderAnswerOp:
 
     def render_single_series_answer(self, analysis: AnalysisResult, *, normalize: bool) -> str:
         return self.answer_service.write_single_series_lookup(analysis, normalize=normalize)
+
+    def render_relationship_answer(self, analysis: AnalysisResult) -> str:
+        return self.answer_service.write_relationship_analysis(analysis)

--- a/src/fred_query/services/operators/series.py
+++ b/src/fred_query/services/operators/series.py
@@ -10,6 +10,9 @@ from fred_query.services.fred_client import FREDClient
 from fred_query.services.operators.models import (
     HistoricalSummaryResult,
     ResolvedSeriesResult,
+    RelationshipMetricsResult,
+    RelationshipSeriesTransformOutput,
+    RelationshipTransformPlan,
     SingleSeriesTransformPlan,
     SingleSeriesTransformOutput,
 )
@@ -28,6 +31,47 @@ class ResolveSeriesOp:
             search_text=search_text,
             geography=intent.geographies[0].name if intent.geographies else "Unspecified",
             indicator=intent.indicators[0] if intent.indicators else "unknown_indicator",
+        )
+        return ResolvedSeriesResult(
+            resolved_series=resolved_series,
+            metadata=metadata,
+            search_match=search_match,
+        )
+
+    @staticmethod
+    def relationship_indicator_for_index(intent: QueryIntent, index: int, fallback: str) -> str:
+        if index < len(intent.indicators) and intent.indicators[index]:
+            return intent.indicators[index]
+        return fallback
+
+    @staticmethod
+    def relationship_search_text_for_index(intent: QueryIntent, index: int) -> str | None:
+        if index < len(intent.search_texts) and intent.search_texts[index]:
+            return intent.search_texts[index]
+        if len(intent.search_texts) == 1:
+            return intent.search_texts[0]
+        if index < len(intent.indicators) and intent.indicators[index]:
+            return intent.indicators[index]
+        return None
+
+    @staticmethod
+    def relationship_series_id_for_index(intent: QueryIntent, index: int) -> str | None:
+        if index < len(intent.series_ids) and intent.series_ids[index]:
+            return intent.series_ids[index]
+        return None
+
+    def for_relationship_target(self, intent: QueryIntent, index: int) -> ResolvedSeriesResult:
+        search_text = self.relationship_search_text_for_index(intent, index)
+        resolved_series, metadata, search_match = self.resolver_service.resolve_series(
+            explicit_series_id=self.relationship_series_id_for_index(intent, index),
+            search_text=search_text,
+            geography="Unspecified",
+            indicator=self.relationship_indicator_for_index(
+                intent,
+                index,
+                search_text or "unknown_indicator",
+            ),
+            no_target_message="I need two resolvable series targets before I can run relationship analysis.",
         )
         return ResolvedSeriesResult(
             resolved_series=resolved_series,
@@ -176,6 +220,103 @@ class ApplyTransformOp:
             compound_annual_growth_rate_pct=compound_annual_growth_rate,
         )
 
+    def plan_relationship(
+        self,
+        intent: QueryIntent,
+        *,
+        metadata_items: list[SeriesMetadata],
+        start_date: date,
+        end_date: date | None,
+    ) -> RelationshipTransformPlan:
+        frequency_code, frequency_label, periods_per_year, lag_unit = (
+            self.transform_service.choose_relationship_frequency(
+                [metadata.frequency for metadata in metadata_items]
+            )
+        )
+        effective_transform = (
+            TransformType.LEVEL if intent.transform == TransformType.NORMALIZED_INDEX else intent.transform
+        )
+        transform_window, transform_warnings = self.transform_service.resolve_transform_window(
+            transform=effective_transform,
+            frequency=metadata_items[0].frequency,
+            requested_window=intent.transform_window,
+        )
+        warmup_periods = self.transform_service.transform_warmup_periods(
+            transform=effective_transform,
+            periods_per_year=periods_per_year,
+            window=transform_window,
+        )
+        fetch_start_date = self.transform_service.subtract_periods(
+            start_date,
+            periods=warmup_periods,
+            frequency=frequency_code,
+        )
+        return RelationshipTransformPlan(
+            start_date=start_date,
+            end_date=end_date,
+            frequency_code=frequency_code,
+            frequency_label=frequency_label,
+            periods_per_year=periods_per_year,
+            lag_unit=lag_unit,
+            requested_transform=intent.transform,
+            effective_transform=effective_transform,
+            normalization=intent.normalization,
+            transform_window=transform_window,
+            warmup_periods=warmup_periods,
+            fetch_start_date=fetch_start_date,
+            warnings=transform_warnings,
+        )
+
+    def apply_relationship_basis(
+        self,
+        observations: list[ObservationPoint],
+        *,
+        metadata: SeriesMetadata,
+        plan: RelationshipTransformPlan,
+    ) -> RelationshipSeriesTransformOutput:
+        visible_observations = self.transform_service.filter_observations_by_date(
+            observations,
+            start_date=plan.start_date,
+            end_date=plan.end_date,
+        )
+        if not visible_observations:
+            raise ValueError(f"No observations returned for {metadata.series_id} in the requested display window.")
+
+        basis_source_observations = observations if plan.warmup_periods > 0 else visible_observations
+        transformed, basis, units, applied_window, basis_warnings = self.transform_service.build_relationship_basis(
+            basis_source_observations,
+            title=metadata.title,
+            units=metadata.units,
+            frequency=metadata.frequency,
+            periods_per_year=plan.periods_per_year,
+            transform=plan.requested_transform,
+            normalization=plan.normalization,
+            requested_window=plan.transform_window,
+        )
+        if not transformed:
+            raise ValueError(
+                f"I could not derive a stable comparison basis for {metadata.series_id} over the requested date range."
+            )
+
+        transformed = self.transform_service.filter_observations_by_date(
+            transformed,
+            start_date=plan.start_date,
+            end_date=plan.end_date,
+        )
+        if not transformed:
+            raise ValueError(
+                f"I could not derive {basis.lower()} for {metadata.series_id} over the requested display window."
+            )
+
+        return RelationshipSeriesTransformOutput(
+            visible_observations=visible_observations,
+            transformed_observations=transformed,
+            basis=basis,
+            units=units,
+            applied_transform_window=applied_window,
+            warnings=basis_warnings,
+        )
+
 
 class AlignSeriesOp:
     def __init__(self, transform_service: TransformService) -> None:
@@ -187,6 +328,36 @@ class AlignSeriesOp:
         second: list[ObservationPoint],
     ) -> tuple[list[ObservationPoint], list[ObservationPoint]]:
         return self.transform_service.align_on_dates(first, second)
+
+    def standardize(self, observations: list[ObservationPoint]) -> list[ObservationPoint]:
+        return self.transform_service.standardize(observations)
+
+
+class ComputeRelationshipMetricsOp:
+    def __init__(self, transform_service: TransformService) -> None:
+        self.transform_service = transform_service
+
+    def compute(
+        self,
+        first: list[ObservationPoint],
+        second: list[ObservationPoint],
+        *,
+        periods_per_year: int,
+    ) -> RelationshipMetricsResult:
+        same_period_correlation = self.transform_service.calculate_correlation(first, second)
+        regression_slope = self.transform_service.calculate_regression_slope(first, second)
+        best_lag, best_lag_correlation, best_lag_samples = self.transform_service.calculate_best_lag_correlation(
+            first,
+            second,
+            max_lag=self.transform_service.relationship_max_lag(periods_per_year),
+        )
+        return RelationshipMetricsResult(
+            same_period_correlation=same_period_correlation,
+            regression_slope=regression_slope,
+            best_lag=best_lag,
+            best_lag_correlation=best_lag_correlation,
+            best_lag_samples=best_lag_samples,
+        )
 
 
 class ComputeSeriesMetricsOp:

--- a/src/fred_query/services/relationship_service.py
+++ b/src/fred_query/services/relationship_service.py
@@ -5,18 +5,25 @@ from datetime import date, timedelta
 from fred_query.schemas.analysis import (
     AnalysisResult,
     DerivedMetric,
-    QueryIntent,
     QueryResponse,
     RelationshipSummary,
     SeriesAnalysis,
 )
-from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata
 from fred_query.services.answer_service import AnswerService
 from fred_query.services.chart_service import ChartService
 from fred_query.services.fred_client import FREDClient
+from fred_query.services.operators import (
+    AlignSeriesOp,
+    ApplyTransformOp,
+    BuildChartOp,
+    ComputeRelationshipMetricsOp,
+    FetchSeriesObservationsOp,
+    RenderAnswerOp,
+    ResolveSeriesOp,
+)
 from fred_query.services.resolver_service import ResolverService
 from fred_query.services.transform_service import TransformService
-from fred_query.schemas.intent import TransformType
+from fred_query.schemas.intent import QueryIntent, TransformType
 
 
 class RelationshipAnalysisService:
@@ -30,41 +37,32 @@ class RelationshipAnalysisService:
         transform_service: TransformService | None = None,
         chart_service: ChartService | None = None,
         answer_service: AnswerService | None = None,
+        resolve_series_op: ResolveSeriesOp | None = None,
+        fetch_observations_op: FetchSeriesObservationsOp | None = None,
+        apply_transform_op: ApplyTransformOp | None = None,
+        align_series_op: AlignSeriesOp | None = None,
+        compute_relationship_metrics_op: ComputeRelationshipMetricsOp | None = None,
+        build_chart_op: BuildChartOp | None = None,
+        render_answer_op: RenderAnswerOp | None = None,
     ) -> None:
         self.fred_client = fred_client
         self.resolver_service = resolver_service or ResolverService(fred_client)
         self.transform_service = transform_service or TransformService()
-        self.transform_planning_service = self.transform_service.planning_service
-        self.series_transform_service = self.transform_service.series_transform_service
-        self.relationship_transform_service = self.transform_service.relationship_transform_service
         self.chart_service = chart_service or ChartService()
         self.answer_service = answer_service or AnswerService()
+        self.resolve_series_op = resolve_series_op or ResolveSeriesOp(self.resolver_service)
+        self.fetch_observations_op = fetch_observations_op or FetchSeriesObservationsOp(self.resolver_service)
+        self.apply_transform_op = apply_transform_op or ApplyTransformOp(self.transform_service)
+        self.align_series_op = align_series_op or AlignSeriesOp(self.transform_service)
+        self.compute_relationship_metrics_op = compute_relationship_metrics_op or ComputeRelationshipMetricsOp(
+            self.transform_service
+        )
+        self.build_chart_op = build_chart_op or BuildChartOp(self.chart_service)
+        self.render_answer_op = render_answer_op or RenderAnswerOp(self.answer_service)
 
     @staticmethod
     def _default_start_date() -> date:
         return date.today() - timedelta(days=365 * 10)
-
-    @staticmethod
-    def _indicator_for_index(intent: QueryIntent, index: int, fallback: str) -> str:
-        if index < len(intent.indicators) and intent.indicators[index]:
-            return intent.indicators[index]
-        return fallback
-
-    @staticmethod
-    def _search_text_for_index(intent: QueryIntent, index: int) -> str | None:
-        if index < len(intent.search_texts) and intent.search_texts[index]:
-            return intent.search_texts[index]
-        if len(intent.search_texts) == 1:
-            return intent.search_texts[0]
-        if index < len(intent.indicators) and intent.indicators[index]:
-            return intent.indicators[index]
-        return None
-
-    @staticmethod
-    def _series_id_for_index(intent: QueryIntent, index: int) -> str | None:
-        if index < len(intent.series_ids) and intent.series_ids[index]:
-            return intent.series_ids[index]
-        return None
 
     @staticmethod
     def _lag_description(first_name: str, second_name: str, lag: int, lag_unit: str) -> str:
@@ -74,126 +72,63 @@ class RelationshipAnalysisService:
             return f"Positive values mean {first_name} tends to lead {second_name} by {lag} {lag_unit}."
         return f"Negative values mean {second_name} tends to lead {first_name} by {abs(lag)} {lag_unit}."
 
-    def _resolve_series(self, intent: QueryIntent, index: int) -> tuple[ResolvedSeries, SeriesMetadata]:
-        resolved, metadata, _ = self.resolver_service.resolve_series(
-            explicit_series_id=self._series_id_for_index(intent, index),
-            search_text=self._search_text_for_index(intent, index),
-            geography="Unspecified",
-            indicator=self._indicator_for_index(
-                intent,
-                index,
-                self._search_text_for_index(intent, index) or "unknown_indicator",
-            ),
-            no_target_message="I need two resolvable series targets before I can run relationship analysis.",
-        )
-        return resolved, metadata
-
     def analyze(self, intent: QueryIntent) -> QueryResponse:
         response_intent = intent.model_copy(deep=True)
-        resolved_series: list[ResolvedSeries] = []
-        metadata_items: list[SeriesMetadata] = []
+        resolved_series = []
+        metadata_items = []
         for index in range(2):
-            resolved, metadata = self._resolve_series(intent, index)
-            resolved_series.append(resolved)
-            metadata_items.append(metadata)
+            target = self.resolve_series_op.for_relationship_target(intent, index)
+            resolved_series.append(target.resolved_series)
+            metadata_items.append(target.metadata)
         response_intent.series_ids = [metadata.series_id for metadata in metadata_items]
         response_intent.search_texts = [
-            self._search_text_for_index(intent, index) or metadata.title
+            self.resolve_series_op.relationship_search_text_for_index(intent, index) or metadata.title
             for index, metadata in enumerate(metadata_items)
         ]
         if not response_intent.indicators:
             response_intent.indicators = [
-                self._indicator_for_index(intent, index, metadata.title)
+                self.resolve_series_op.relationship_indicator_for_index(intent, index, metadata.title)
                 for index, metadata in enumerate(metadata_items)
             ]
 
-        frequency_code, frequency_label, periods_per_year, lag_unit = (
-            self.relationship_transform_service.choose_relationship_frequency(
-                [metadata.frequency for metadata in metadata_items]
-            )
-        )
-
         start_date = intent.start_date or self._default_start_date()
         end_date = intent.end_date
-        effective_transform = (
-            TransformType.LEVEL if intent.transform == TransformType.NORMALIZED_INDEX else intent.transform
+        transform_plan = self.apply_transform_op.plan_relationship(
+            intent,
+            metadata_items=metadata_items,
+            start_date=start_date,
+            end_date=end_date,
         )
-        transform_window, transform_warnings = self.transform_planning_service.resolve_transform_window(
-            transform=effective_transform,
-            frequency=metadata_items[0].frequency,
-            requested_window=intent.transform_window,
-        )
-        warmup_periods = self.transform_planning_service.transform_warmup_periods(
-            transform=effective_transform,
-            periods_per_year=periods_per_year,
-            window=transform_window,
-        )
-        fetch_start_date = self.transform_planning_service.subtract_periods(
-            start_date,
-            periods=warmup_periods,
-            frequency=frequency_code,
-        )
-        raw_observations: list[list] = []
-        transformed_observations: list[list] = []
+        raw_observations = []
+        transformed_observations = []
         bases: list[str] = []
         analysis_units: list[str] = []
-        warnings = list(transform_warnings)
+        warnings = list(transform_plan.warnings)
         applied_transform_window: int | None = None
 
         for metadata in metadata_items:
-            observations = self.resolver_service.get_required_observations(
+            observations = self.fetch_observations_op.fetch(
                 metadata.series_id,
-                start_date=fetch_start_date,
+                start_date=transform_plan.fetch_start_date,
                 end_date=end_date,
-                frequency=frequency_code,
+                frequency=transform_plan.frequency_code,
                 aggregation_method="avg",
             )
-
-            visible_observations = self.series_transform_service.filter_observations_by_date(
+            transformed = self.apply_transform_op.apply_relationship_basis(
                 observations,
-                start_date=start_date,
-                end_date=end_date,
+                metadata=metadata,
+                plan=transform_plan,
             )
-            if not visible_observations:
-                raise ValueError(f"No observations returned for {metadata.series_id} in the requested display window.")
 
-            basis_source_observations = observations if warmup_periods > 0 else visible_observations
-            transformed, basis, units, applied_window, basis_warnings = (
-                self.relationship_transform_service.build_relationship_basis(
-                    basis_source_observations,
-                    title=metadata.title,
-                    units=metadata.units,
-                    frequency=metadata.frequency,
-                    periods_per_year=periods_per_year,
-                    transform=intent.transform,
-                    normalization=intent.normalization,
-                    requested_window=transform_window,
-                )
-            )
-            if not transformed:
-                raise ValueError(
-                    f"I could not derive a stable comparison basis for {metadata.series_id} over the requested date range."
-                )
+            raw_observations.append(transformed.visible_observations)
+            transformed_observations.append(transformed.transformed_observations)
+            bases.append(transformed.basis)
+            analysis_units.append(transformed.units)
+            if transformed.applied_transform_window is not None:
+                applied_transform_window = transformed.applied_transform_window
+            warnings.extend(transformed.warnings)
 
-            transformed = self.series_transform_service.filter_observations_by_date(
-                transformed,
-                start_date=start_date,
-                end_date=end_date,
-            )
-            if not transformed:
-                raise ValueError(
-                    f"I could not derive {basis.lower()} for {metadata.series_id} over the requested display window."
-                )
-
-            raw_observations.append(visible_observations)
-            transformed_observations.append(transformed)
-            bases.append(basis)
-            analysis_units.append(units)
-            if applied_window is not None:
-                applied_transform_window = applied_window
-            warnings.extend(basis_warnings)
-
-        aligned_first, aligned_second = self.relationship_transform_service.align_on_dates(
+        aligned_first, aligned_second = self.align_series_op.align(
             transformed_observations[0],
             transformed_observations[1],
         )
@@ -202,20 +137,10 @@ class RelationshipAnalysisService:
                 "The two series do not have enough overlapping observations after alignment to estimate a relationship safely."
             )
 
-        same_period_correlation = self.relationship_transform_service.calculate_correlation(
+        relationship_metrics = self.compute_relationship_metrics_op.compute(
             aligned_first,
             aligned_second,
-        )
-        regression_slope = self.relationship_transform_service.calculate_regression_slope(
-            aligned_first,
-            aligned_second,
-        )
-        best_lag, best_lag_correlation, best_lag_samples = (
-            self.relationship_transform_service.calculate_best_lag_correlation(
-                aligned_first,
-                aligned_second,
-                max_lag=self.relationship_transform_service.relationship_max_lag(periods_per_year),
-            )
+            periods_per_year=transform_plan.periods_per_year,
         )
 
         chart_series = [aligned_first, aligned_second]
@@ -228,8 +153,8 @@ class RelationshipAnalysisService:
         chart_basis = basis_summary
         if analysis_units[0] != analysis_units[1]:
             chart_series = [
-                self.relationship_transform_service.standardize(aligned_first),
-                self.relationship_transform_service.standardize(aligned_second),
+                self.align_series_op.standardize(aligned_first),
+                self.align_series_op.standardize(aligned_second),
             ]
             chart_units = "Standard deviations"
             chart_basis = "Standardized relationship basis"
@@ -262,7 +187,7 @@ class RelationshipAnalysisService:
             DerivedMetric(
                 name="common_frequency",
                 label="Common frequency",
-                value=frequency_label,
+                value=transform_plan.frequency_label,
                 description="Frequency used to align the two series before estimating the relationship.",
             ),
             DerivedMetric(
@@ -273,7 +198,7 @@ class RelationshipAnalysisService:
                 description="Number of aligned observations used in the same-period relationship estimate.",
             ),
         ]
-        if applied_transform_window is not None and effective_transform in (
+        if applied_transform_window is not None and transform_plan.effective_transform in (
             TransformType.ROLLING_AVERAGE,
             TransformType.ROLLING_STDDEV,
             TransformType.ROLLING_VOLATILITY,
@@ -287,22 +212,22 @@ class RelationshipAnalysisService:
                 )
             )
 
-        if same_period_correlation is not None:
+        if relationship_metrics.same_period_correlation is not None:
             derived_metrics.append(
                 DerivedMetric(
                     name="same_period_correlation",
                     label="Same-period correlation",
-                    value=round(same_period_correlation, 4),
+                    value=round(relationship_metrics.same_period_correlation, 4),
                     description="Pearson correlation on the aligned analysis basis in the same period.",
                 )
             )
 
-        if regression_slope is not None:
+        if relationship_metrics.regression_slope is not None:
             derived_metrics.append(
                 DerivedMetric(
                     name="regression_slope",
                     label="Regression slope",
-                    value=round(regression_slope, 4),
+                    value=round(relationship_metrics.regression_slope, 4),
                     description=(
                         f"Simple linear slope of {resolved_series[1].series_id} on {resolved_series[0].series_id} "
                         "using the aligned analysis basis."
@@ -310,28 +235,28 @@ class RelationshipAnalysisService:
                 )
             )
 
-        if best_lag is not None and best_lag_correlation is not None:
+        if relationship_metrics.best_lag is not None and relationship_metrics.best_lag_correlation is not None:
             derived_metrics.extend(
                 [
                     DerivedMetric(
                         name="strongest_lag_periods",
                         label="Strongest lag",
-                        value=best_lag,
-                        unit=lag_unit,
+                        value=relationship_metrics.best_lag,
+                        unit=transform_plan.lag_unit,
                         description=self._lag_description(
                             resolved_series[0].series_id,
                             resolved_series[1].series_id,
-                            best_lag,
-                            lag_unit,
+                            relationship_metrics.best_lag,
+                            transform_plan.lag_unit,
                         ),
                     ),
                     DerivedMetric(
                         name="strongest_lag_correlation",
                         label="Strongest lag correlation",
-                        value=round(best_lag_correlation, 4),
+                        value=round(relationship_metrics.best_lag_correlation, 4),
                         description=(
-                            f"Absolute strongest correlation in the tested lead-lag window using {best_lag_samples} "
-                            "overlapping observations."
+                            "Absolute strongest correlation in the tested lead-lag window using "
+                            f"{relationship_metrics.best_lag_samples} overlapping observations."
                         ),
                     ),
                 ]
@@ -342,32 +267,36 @@ class RelationshipAnalysisService:
             derived_metrics=derived_metrics,
             relationship_summary=RelationshipSummary(
                 analysis_basis=basis_summary,
-                common_frequency=frequency_label,
+                common_frequency=transform_plan.frequency_label,
                 overlap_observations=len(aligned_first),
-                same_period_correlation=round(same_period_correlation, 4)
-                if same_period_correlation is not None
+                same_period_correlation=round(relationship_metrics.same_period_correlation, 4)
+                if relationship_metrics.same_period_correlation is not None
                 else None,
-                regression_slope=round(regression_slope, 4) if regression_slope is not None else None,
-                strongest_lag_periods=best_lag,
-                strongest_lag_unit=lag_unit if best_lag is not None else None,
-                strongest_lag_correlation=round(best_lag_correlation, 4)
-                if best_lag_correlation is not None
+                regression_slope=(
+                    round(relationship_metrics.regression_slope, 4)
+                    if relationship_metrics.regression_slope is not None
+                    else None
+                ),
+                strongest_lag_periods=relationship_metrics.best_lag,
+                strongest_lag_unit=transform_plan.lag_unit if relationship_metrics.best_lag is not None else None,
+                strongest_lag_correlation=round(relationship_metrics.best_lag_correlation, 4)
+                if relationship_metrics.best_lag_correlation is not None
                 else None,
-                strongest_lag_observations=best_lag_samples,
+                strongest_lag_observations=relationship_metrics.best_lag_samples,
             ),
             warnings=warnings,
             latest_observation_date=max(latest_dates),
             coverage_start=aligned_first[0].date,
             coverage_end=aligned_first[-1].date,
         )
-        chart = self.chart_service.build_relationship_chart(
+        chart = self.build_chart_op.build_relationship_chart(
             series_results=series_results,
-            frequency_label=frequency_label,
+            frequency_label=transform_plan.frequency_label,
             chart_basis=chart_basis,
             chart_units=chart_units,
             start_date=aligned_first[0].date,
             end_date=aligned_first[-1].date,
         )
-        answer_text = self.answer_service.write_relationship_analysis(analysis)
+        answer_text = self.render_answer_op.render_relationship_answer(analysis)
         response_intent.refresh_query_plan()
         return QueryResponse(intent=response_intent, analysis=analysis, chart=chart, answer_text=answer_text)

--- a/tests/test_series_operators.py
+++ b/tests/test_series_operators.py
@@ -4,10 +4,11 @@ from datetime import date, timedelta
 import unittest
 
 from fred_query.schemas.analysis import ObservationPoint, SeriesAnalysis
-from fred_query.schemas.intent import QueryIntent, TaskType, TransformType
+from fred_query.schemas.intent import ComparisonMode, QueryIntent, TaskType, TransformType
 from fred_query.schemas.resolved_series import ResolvedSeries, SeriesMetadata
 from fred_query.services.operators import (
     ApplyTransformOp,
+    ComputeRelationshipMetricsOp,
     FetchSeriesObservationsOp,
     RankSeriesOp,
     ResolveSeriesOp,
@@ -89,6 +90,20 @@ class SeriesOperatorsTest(unittest.TestCase):
 
         self.assertEqual([point.date for point in observations], [date(2024, 1, 1), date(2024, 2, 1)])
 
+    def test_resolve_series_op_supports_relationship_targets(self) -> None:
+        resolver = ResolverService(_OperatorFREDClient())
+        op = ResolveSeriesOp(resolver)
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            series_ids=["UNRATE", "SP500"],
+        )
+
+        result = op.for_relationship_target(intent, 1)
+
+        self.assertEqual(result.metadata.series_id, "SP500")
+        self.assertEqual(result.resolved_series.series_id, "SP500")
+
     def test_apply_transform_op_plans_warmup_and_applies_visible_transform(self) -> None:
         transform_service = TransformService()
         op = ApplyTransformOp(transform_service)
@@ -120,6 +135,55 @@ class SeriesOperatorsTest(unittest.TestCase):
         self.assertEqual(plan.fetch_start_date, date(2024, 1, 2))
         self.assertEqual(result.analysis_basis, "30-observation rolling annualized volatility")
         self.assertEqual(result.transformed_observations[0].date, date(2024, 2, 1))
+
+    def test_apply_transform_op_plans_relationship_basis(self) -> None:
+        transform_service = TransformService()
+        op = ApplyTransformOp(transform_service)
+        client = _OperatorFREDClient()
+        metadata_items = [
+            client.get_series_metadata("SP500"),
+            client.get_series_metadata("UNRATE"),
+        ]
+        intent = QueryIntent(
+            task_type=TaskType.RELATIONSHIP_ANALYSIS,
+            comparison_mode=ComparisonMode.RELATIONSHIP,
+            transform=TransformType.NORMALIZED_INDEX,
+            normalization=True,
+        )
+
+        plan = op.plan_relationship(
+            intent,
+            metadata_items=metadata_items,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 2, 15),
+        )
+        output = op.apply_relationship_basis(
+            client.get_series_observations("SP500", start_date=plan.fetch_start_date, end_date=plan.end_date),
+            metadata=metadata_items[0],
+            plan=plan,
+        )
+
+        self.assertEqual(plan.frequency_code, "m")
+        self.assertEqual(plan.frequency_label, "Monthly")
+        self.assertEqual(output.basis, "Normalized index")
+        self.assertEqual(output.units, "Index (Base = 100)")
+
+    def test_compute_relationship_metrics_op_returns_pairwise_statistics(self) -> None:
+        op = ComputeRelationshipMetricsOp(TransformService())
+        first = [
+            ObservationPoint(date=date(2024, month, 1), value=float(month))
+            for month in range(1, 13)
+        ]
+        second = [
+            ObservationPoint(date=date(2024, month, 1), value=float(month * 2))
+            for month in range(1, 13)
+        ]
+
+        metrics = op.compute(first, second, periods_per_year=12)
+
+        self.assertAlmostEqual(metrics.same_period_correlation or 0.0, 1.0, places=6)
+        self.assertAlmostEqual(metrics.regression_slope or 0.0, 2.0, places=6)
+        self.assertIsNotNone(metrics.best_lag)
 
     def test_rank_series_op_orders_by_latest_value(self) -> None:
         first = SeriesAnalysis(


### PR DESCRIPTION
Add dataclasses for relationship transforms and metrics (RelationshipTransformPlan, RelationshipSeriesTransformOutput, RelationshipMetricsResult) and export them from the operators package. Introduce new operator methods and classes: ResolveSeriesOp helpers for relationship targets, ApplyTransformOp.plan_relationship and apply_relationship_basis, AlignSeriesOp.standardize, and ComputeRelationshipMetricsOp for correlation/regression/lag metrics. Add presentation hooks (BuildChartOp.build_relationship_chart, RenderAnswerOp.render_relationship_answer). Refactor RelationshipAnalysisService to use these operators (dependency-injectable ops) and simplify relationship analysis flow. Update tests to exercise the new operators and metrics. This modularizes relationship analysis logic and improves testability and reuse.